### PR TITLE
fix: tests without deprecation warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        php: [8.0, 8.1, 8.2]
+        php: [8.1, 8.2, 8.3]
         os: [ubuntu-latest, macos-latest, windows-latest]
         dependencies: [ 'lowest', 'highest' ]
-    continue-on-error: ${{ matrix.os == 'windows-latest' && matrix.php == '8.2' }}
+    continue-on-error: ${{ matrix.os == 'windows-latest' && matrix.php != '8.1' }}
     name: PHP ${{ matrix.php }} - OS ${{ matrix.os }} - Dependencies ${{ matrix.dependencies }}
     steps:
       - uses: actions/checkout@v3
@@ -32,12 +32,12 @@ jobs:
             extensions: curl, zip, rar, bz2
             coverage: pcov
             tools: composer:v2
-      - name: Install unrar on Ubuntu with PHP 8.1 & 8.2
+      - name: Install unrar on Ubuntu
         run: sudo apt install unrar
-        if: ${{ matrix.os == 'ubuntu-latest' && contains(fromJson('["8.1", "8.2"]'), matrix.php) }}
-      - name: Install unrar on MacOS with PHP 8.1 & 8.2
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+      - name: Install unrar on MacOS
         run: brew install rar
-        if: ${{ matrix.os == 'macos-latest' && contains(fromJson('["8.1", "8.2"]'), matrix.php) }}
+        if: ${{ matrix.os == 'macos-latest' }}
       - name: Validate composer.json
         run: composer validate
       - uses: ramsey/composer-install@v2

--- a/composer.json
+++ b/composer.json
@@ -17,18 +17,17 @@
             "email": "tien.xuan.vo@gmail.com"
         }
     ],
-    "version": "2.0.0",
     "require": {
         "composer-plugin-api": "^2.0",
-        "php": "^8.0",
+        "php": "^8.1",
         "leongrdic/smplang": "^1.0.2",
-        "symfony/filesystem": "^7.0.3",
-        "symfony/finder": "^7.0.0"
+        "symfony/filesystem": "^6.0 || ^7.0",
+        "symfony/finder": "^6.0 || ^7.0"
     },
     "require-dev": {
         "composer/composer": "^2.2",
         "phpunit/phpunit": "^9.5.10",
-        "symfony/process": "^7.0.4",
+        "symfony/process": "^6.0 || ^7.0",
         "php-vfs/php-vfs": "^1.4"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,13 @@
         "composer-plugin-api": "^2.0",
         "php": "^8.1",
         "leongrdic/smplang": "^1.0.2",
-        "symfony/filesystem": "^6.0 || ^7.0",
-        "symfony/finder": "^6.0 || ^7.0"
+        "symfony/filesystem": "^5.4 || ^6.0 || ^7.0",
+        "symfony/finder": "^5.4 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "composer/composer": "^2.3",
         "phpunit/phpunit": "^9.5.10",
-        "symfony/process": "^6.0 || ^7.0",
+        "symfony/process": "^5.4 || ^6.0 || ^7.0",
         "php-vfs/php-vfs": "^1.4",
         "friendsofphp/php-cs-fixer": "^3.51"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,17 +17,18 @@
             "email": "tien.xuan.vo@gmail.com"
         }
     ],
+    "version": "2.0.0",
     "require": {
-        "composer-plugin-api": "^1.1 || ^2.0",
+        "composer-plugin-api": "^2.0",
         "php": "^8.0",
         "leongrdic/smplang": "^1.0.2",
-        "symfony/filesystem": "^5.4 || ^6.0",
-        "symfony/finder": "^4.4.23 || ^5.4 || ^6.0"
+        "symfony/filesystem": "^7.0.3",
+        "symfony/finder": "^7.0.0"
     },
     "require-dev": {
-        "composer/composer": "^1.10.26 || ^2.2",
+        "composer/composer": "^2.2",
         "phpunit/phpunit": "^9.5.10",
-        "symfony/process": "^4.4 || ^5.4 || ^6.0",
+        "symfony/process": "^7.0.4",
         "php-vfs/php-vfs": "^1.4"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "composer/composer": "^2.2",
         "phpunit/phpunit": "^9.5.10",
         "symfony/process": "^6.0 || ^7.0",
-        "php-vfs/php-vfs": "^1.4"
+        "php-vfs/php-vfs": "^1.4",
+        "friendsofphp/php-cs-fixer": "^3.51"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,13 @@
         "composer-plugin-api": "^2.0",
         "php": "^8.1",
         "leongrdic/smplang": "^1.0.2",
-        "symfony/filesystem": "^5.4 || ^6.0 || ^7.0",
-        "symfony/finder": "^5.4 || ^6.0 || ^7.0"
+        "symfony/filesystem": "^5.4 || ^6.4 || ^7.0",
+        "symfony/finder": "^5.4 || ^6.4 || ^7.0"
     },
     "require-dev": {
         "composer/composer": "^2.3",
         "phpunit/phpunit": "^9.5.10",
-        "symfony/process": "^5.4 || ^6.0 || ^7.0",
+        "symfony/process": "^5.4 || ^6.4 || ^7.0",
         "php-vfs/php-vfs": "^1.4",
         "friendsofphp/php-cs-fixer": "^3.51"
     },

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/finder": "^6.0 || ^7.0"
     },
     "require-dev": {
-        "composer/composer": "^2.2",
+        "composer/composer": "^2.3",
         "phpunit/phpunit": "^9.5.10",
         "symfony/process": "^6.0 || ^7.0",
         "php-vfs/php-vfs": "^1.4",

--- a/src/Handler/ArchiveHandler.php
+++ b/src/Handler/ArchiveHandler.php
@@ -51,14 +51,10 @@ abstract class ArchiveHandler extends BaseHandler
         $downloadManager = $composer->getDownloadManager();
 
         // In composer:v2, download and extract were separated.
-        if ($this->isComposerV2()) {
-            $promise = $downloadManager->download($this->subpackage, $targetPath);
-            $composer->getLoop()->wait([$promise]);
-            $promise = $downloadManager->install($this->subpackage, $targetPath);
-            $composer->getLoop()->wait([$promise]);
-        } else {
-            $downloadManager->download($this->subpackage, $targetPath);
-        }
+        $promise = $downloadManager->download($this->subpackage, $targetPath);
+        $composer->getLoop()->wait([$promise]);
+        $promise = $downloadManager->install($this->subpackage, $targetPath);
+        $composer->getLoop()->wait([$promise]);
         $this->cleaner->clean($targetPath, $this->subpackage->getIgnore());
     }
 }

--- a/src/Handler/BaseHandler.php
+++ b/src/Handler/BaseHandler.php
@@ -60,11 +60,6 @@ abstract class BaseHandler implements HandlerInterface
         ];
     }
 
-    protected function isComposerV2(): bool
-    {
-        return version_compare(Composer::RUNTIME_API_VERSION, '2.0.0') >= 0;
-    }
-
     public function install(Composer $composer, IOInterface $io): void
     {
         $this->download($composer, $io);

--- a/src/Handler/FileHandler.php
+++ b/src/Handler/FileHandler.php
@@ -46,6 +46,7 @@ class FileHandler extends BaseHandler
         $promise = $downloadManager->download($this->subpackage, \dirname($target));
         $promise->then(static function ($res) use (&$file) {
             $file = $res;
+
             return \React\Promise\resolve($res);
         });
         $composer->getLoop()->wait([$promise]);

--- a/src/Handler/GzipHandler.php
+++ b/src/Handler/GzipHandler.php
@@ -15,14 +15,10 @@ class GzipHandler extends FileHandler
 
         $this->filesystem->ensureDirectoryExists($tmpDir);
         // In composer:v2, download and extract were separated.
-        if ($this->isComposerV2()) {
-            $promise = $downloadManager->download($this->subpackage, $tmpDir);
-            $composer->getLoop()->wait([$promise]);
-            $promise = $downloadManager->install($this->subpackage, $tmpDir);
-            $composer->getLoop()->wait([$promise]);
-        } else {
-            $downloadManager->download($this->subpackage, $tmpDir);
-        }
+        $promise = $downloadManager->download($this->subpackage, $tmpDir);
+        $composer->getLoop()->wait([$promise]);
+        $promise = $downloadManager->install($this->subpackage, $tmpDir);
+        $composer->getLoop()->wait([$promise]);
         $this->filesystem->rename($tmpDir.\DIRECTORY_SEPARATOR.$targetName, $this->subpackage->getTargetPath());
         $this->filesystem->remove($tmpDir);
     }

--- a/tests/Unit/Handler/ArchiveHandlerTestCase.php
+++ b/tests/Unit/Handler/ArchiveHandlerTestCase.php
@@ -27,31 +27,24 @@ abstract class ArchiveHandlerTestCase extends BaseHandlerTestCase
     protected function assertDownload(): void
     {
         $this->composer->expects($this->once())->method('getDownloadManager')->willReturn($this->downloadManager);
-        if ($this->isComposerV2) {
-            $this->downloadManager
-                ->expects($this->once())
-                ->method('download')
-                ->with($this->isInstanceOf(Subpackage::class), $this->targetPath)
-                ->willReturn($this->downloadPromise);
-            $this->downloadManager
-                ->expects($this->once())
-                ->method('install')
-                ->with($this->isInstanceOf(Subpackage::class), $this->targetPath)
-                ->willReturn($this->installPromise);
-            $this->loop
-                ->expects($this->exactly(2))
-                ->method('wait')
-                ->withConsecutive(
-                    [[$this->downloadPromise]],
-                    [[$this->installPromise]]
-                );
-            $this->composer->expects($this->exactly(2))->method('getLoop')->willReturn($this->loop);
-        } else {
-            $this->downloadManager
-                ->expects($this->once())
-                ->method('download')
-                ->with($this->isInstanceOf(Subpackage::class), $this->targetPath);
-        }
+        $this->downloadManager
+            ->expects($this->once())
+            ->method('download')
+            ->with($this->isInstanceOf(Subpackage::class), $this->targetPath)
+            ->willReturn($this->downloadPromise);
+        $this->downloadManager
+            ->expects($this->once())
+            ->method('install')
+            ->with($this->isInstanceOf(Subpackage::class), $this->targetPath)
+            ->willReturn($this->installPromise);
+        $this->loop
+            ->expects($this->exactly(2))
+            ->method('wait')
+            ->withConsecutive(
+                [[$this->downloadPromise]],
+                [[$this->installPromise]]
+            );
+        $this->composer->expects($this->exactly(2))->method('getLoop')->willReturn($this->loop);
         $this->cleaner->expects($this->once())->method('clean')->with($this->targetPath, $this->ignore);
     }
 

--- a/tests/Unit/Handler/BaseHandlerTestCase.php
+++ b/tests/Unit/Handler/BaseHandlerTestCase.php
@@ -25,7 +25,6 @@ abstract class BaseHandlerTestCase extends TestCase
     protected Loop|MockObject $loop;
     private Subpackage $subpackage;
     private HandlerInterface $handler;
-    protected bool $isComposerV2;
     private string $parentPath = '/path/to/package';
     protected string $id = 'sub-package-name';
     protected string $url = 'http://example.com/file.ext';
@@ -41,12 +40,9 @@ abstract class BaseHandlerTestCase extends TestCase
         $this->io = $this->createMock(IOInterface::class);
         $this->downloadManager = $this->createMock(DownloadManager::class);
         $this->binariesInstaller = $this->createMock(BinariesInstaller::class);
-        $this->isComposerV2 = version_compare(Composer::RUNTIME_API_VERSION, '2.0.0') >= 0;
-        if ($this->isComposerV2) {
-            $this->downloadPromise = $this->createMock(PromiseInterface::class);
-            $this->installPromise = $this->createMock(PromiseInterface::class);
-            $this->loop = $this->createMock(Loop::class);
-        }
+        $this->downloadPromise = $this->createMock(PromiseInterface::class);
+        $this->installPromise = $this->createMock(PromiseInterface::class);
+        $this->loop = $this->createMock(Loop::class);
         $this->extraFile = [
             'id' => $this->id,
             'url' => $this->url,

--- a/tests/Unit/Handler/FileHandlerTest.php
+++ b/tests/Unit/Handler/FileHandlerTest.php
@@ -47,49 +47,22 @@ class FileHandlerTest extends BaseHandlerTestCase
     protected function assertDownload(): void
     {
         $this->composer->expects($this->once())->method('getDownloadManager')->willReturn($this->downloadManager);
-        if ($this->isComposerV2) {
-            $tmpFile = '/path/to/vendor/composer/tmp-random';
-            $this->downloadPromise
-                ->expects($this->once())
-                ->method('then')
-                ->willReturnCallback(fn (callable $callback) => $callback($tmpFile));
-            $this->downloadManager
-                ->expects($this->once())
-                ->method('download')
-                ->with($this->isInstanceOf(Subpackage::class), \dirname($this->targetPath))
-                ->willReturn($this->downloadPromise);
-            $this->loop
-                ->expects($this->once())
-                ->method('wait')
-                ->with([$this->downloadPromise]);
-            $this->composer->expects($this->once())->method('getLoop')->willReturn($this->loop);
-            $this->filesystem->expects($this->once())->method('rename')->with($tmpFile, $this->targetPath);
-        } else {
-            $downloader = $this->createMock(FileDownloader::class);
-            $this->filesystem
-                ->expects($this->once())
-                ->method('ensureDirectoryExists')
-                ->with($this->callback(function (string $dir) use ($downloader): bool {
-                    $this->assertStringContainsString(\dirname($this->targetPath), $dir);
-                    $this->assertStringContainsString(FileHandler::TMP_PREFIX, $dir);
-                    $tmpDir = $dir;
-                    $tmpFile = $tmpDir.\DIRECTORY_SEPARATOR.'file';
-                    $downloader
-                        ->expects($this->once())
-                        ->method('download')
-                        ->with($this->isInstanceOf(Subpackage::class), $tmpDir)
-                        ->willReturn($tmpFile);
-                    $this->filesystem->expects($this->once())->method('rename')->with($tmpFile, $this->targetPath);
-                    $this->filesystem->expects($this->once())->method('remove')->with($tmpDir);
-
-                    return true;
-                }));
-            $this->downloadManager
-                ->expects($this->once())
-                ->method('getDownloader')
-                ->with('file')
-                ->willReturn($downloader);
-        }
+        $tmpFile = '/path/to/vendor/composer/tmp-random';
+        $this->downloadPromise
+            ->expects($this->once())
+            ->method('then')
+            ->willReturnCallback(fn (callable $callback) => $callback($tmpFile));
+        $this->downloadManager
+            ->expects($this->once())
+            ->method('download')
+            ->with($this->isInstanceOf(Subpackage::class), \dirname($this->targetPath))
+            ->willReturn($this->downloadPromise);
+        $this->loop
+            ->expects($this->once())
+            ->method('wait')
+            ->with([$this->downloadPromise]);
+        $this->composer->expects($this->once())->method('getLoop')->willReturn($this->loop);
+        $this->filesystem->expects($this->once())->method('rename')->with($tmpFile, $this->targetPath);
     }
 
     protected function getExecutableType(): string

--- a/tests/Unit/Handler/FileHandlerTest.php
+++ b/tests/Unit/Handler/FileHandlerTest.php
@@ -2,7 +2,6 @@
 
 namespace LastCall\DownloadsPlugin\Tests\Unit;
 
-use Composer\Downloader\FileDownloader;
 use Composer\Util\Filesystem;
 use LastCall\DownloadsPlugin\Handler\FileHandler;
 use LastCall\DownloadsPlugin\Subpackage;

--- a/tests/Unit/Handler/GzipHandlerTest.php
+++ b/tests/Unit/Handler/GzipHandlerTest.php
@@ -26,16 +26,14 @@ class GzipHandlerTest extends FileHandlerTest
     protected function assertDownload(): void
     {
         $this->composer->expects($this->once())->method('getDownloadManager')->willReturn($this->downloadManager);
-        if ($this->isComposerV2) {
-            $this->loop
-                ->expects($this->exactly(2))
-                ->method('wait')
-                ->withConsecutive(
-                    [[$this->downloadPromise]],
-                    [[$this->installPromise]]
-                );
-            $this->composer->expects($this->exactly(2))->method('getLoop')->willReturn($this->loop);
-        }
+        $this->loop
+            ->expects($this->exactly(2))
+            ->method('wait')
+            ->withConsecutive(
+                [[$this->downloadPromise]],
+                [[$this->installPromise]]
+            );
+        $this->composer->expects($this->exactly(2))->method('getLoop')->willReturn($this->loop);
         $this->filesystem
             ->expects($this->once())
             ->method('ensureDirectoryExists')
@@ -44,23 +42,16 @@ class GzipHandlerTest extends FileHandlerTest
                 $this->assertStringContainsString(FileHandler::TMP_PREFIX, $dir);
                 $tmpDir = $dir;
                 $tmpFile = $tmpDir.\DIRECTORY_SEPARATOR.'file';
-                if ($this->isComposerV2) {
-                    $this->downloadManager
-                        ->expects($this->once())
-                        ->method('download')
-                        ->with($this->isInstanceOf(Subpackage::class), $tmpDir)
-                        ->willReturn($this->downloadPromise);
-                    $this->downloadManager
-                        ->expects($this->once())
-                        ->method('install')
-                        ->with($this->isInstanceOf(Subpackage::class), $tmpDir)
-                        ->willReturn($this->installPromise);
-                } else {
-                    $this->downloadManager
-                        ->expects($this->once())
-                        ->method('download')
-                        ->with($this->isInstanceOf(Subpackage::class), $tmpDir);
-                }
+                $this->downloadManager
+                    ->expects($this->once())
+                    ->method('download')
+                    ->with($this->isInstanceOf(Subpackage::class), $tmpDir)
+                    ->willReturn($this->downloadPromise);
+                $this->downloadManager
+                    ->expects($this->once())
+                    ->method('install')
+                    ->with($this->isInstanceOf(Subpackage::class), $tmpDir)
+                    ->willReturn($this->installPromise);
                 $this->filesystem->expects($this->once())->method('rename')->with($tmpFile, $this->targetPath);
                 $this->filesystem->expects($this->once())->method('remove')->with($tmpDir);
 


### PR DESCRIPTION
- Updates packages
- Removes branching logic about composer 1.x
- Ensures a Promise is returned when downloading file
- Documented php-cs-fixer dependency as a dev dependency
- fixed GitHub actions build matrix for php 8.1 - 8.3