### PR TITLE
ci: Split ci jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,26 +15,29 @@ jobs:
     runs-on: ubuntu-latest
     name: PHP CS FIXER
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: PHP-CS-Fixer
         uses: docker://oskarstark/php-cs-fixer-ga
         with:
           args: --diff --dry-run
-  phpunit:
+
+  integration:
     runs-on: ${{ matrix.os }}
+    needs:
+      - php-cs-fixer
     strategy:
+      fail-fast: false
       matrix:
         php: [8.1, 8.2, 8.3]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        dependencies: [ 'lowest', 'highest' ]
-    name: PHP ${{ matrix.php }} - OS ${{ matrix.os }} - Dependencies ${{ matrix.dependencies }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        name: Checkout repository
       - uses: shivammathur/setup-php@v2
         with:
             php-version: ${{ matrix.php }}
             extensions: curl, zip, rar, bz2
-            coverage: pcov
+            coverage: none
             tools: composer:v2
       - name: Install unrar on Ubuntu
         run: sudo apt install unrar
@@ -42,18 +45,38 @@ jobs:
       - name: Install unrar on MacOS
         run: brew install rar
         if: ${{ matrix.os == 'macos-latest' }}
+      - uses: ramsey/composer-install@v3
+        with:
+          dependency-versions: 'highest'
+      - name: Run integration tests
+        run: ./vendor/bin/phpunit --testsuite=Integration
+
+  unit:
+    runs-on: ubuntu-latest
+    needs:
+      - php-cs-fixer
+    strategy:
+      matrix:
+        php: [8.1, 8.2, 8.3]
+        dependencies: [ 'lowest', 'highest' ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+            php-version: ${{ matrix.php }}
+            coverage: pcov
       - name: Validate composer.json
         run: composer validate
-      - uses: ramsey/composer-install@v2
+      - uses: ramsey/composer-install@v3
         with:
           dependency-versions: ${{ matrix.dependencies }}
           composer-options: "--no-progress --no-suggest"
-      - name: Run tests
-        run: ./vendor/bin/phpunit
+      - name: Run unit tests
+        run: ./vendor/bin/phpunit --testsuite=Unit
       - name: Upload coverage results to Coveralls
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           composer global require php-coveralls/php-coveralls
           php-coveralls --coverage_clover=clover.xml -v
-        if: ${{ github.event_name == 'push' && matrix.os == 'ubuntu-latest' && matrix.php == '8.1' && matrix.dependencies == 'highest' }}
+        if: ${{ github.event_name == 'push' && matrix.php == '8.1' && matrix.dependencies == 'highest' }}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit colors="true" bootstrap="vendor/autoload.php" defaultTestSuite="Plugin">
+<phpunit colors="true" bootstrap="vendor/autoload.php">
     <testsuites>
-        <testsuite name="Plugin">
-            <directory>tests</directory>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Integration">
+            <directory>tests/Integration</directory>
         </testsuite>
     </testsuites>
 


### PR DESCRIPTION
Apply the same strategy from Pact PHP to this project:

* Remove `php-unit` job, instead:
* Add `integration` job:
  * No need to run on multiple dependency configurations, only `highest` is enough
  * Need to run on multiple php versions 8.1 -> 8.3
  * Disable code coverage
  * ~~Windows: Because of rar extension can't be installed on PHP 8.2 & 8.3 , only run Integration tests on PHP 8.1~~
* Add `unit` job:
  * No need to run on multiple os, only `ubuntu` is enough
  * Need to run on multiple php versions `8.1 -> 8.3`
  * Need to run on multiple dependency configurations `lowest/highest`
  * Enable code coverage: pcov
* Update github actions to remove node's version warnings

Depend on https://github.com/pact-foundation/composer-downloads-plugin/pull/4