### PR TITLE
fix: skip rar files for windows > 8.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,12 @@
 name: main
 
 on:
-  push:
   pull_request:
     branches: [ main ]
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   php-cs-fixer:
@@ -22,7 +25,6 @@ jobs:
         php: [8.1, 8.2, 8.3]
         os: [ubuntu-latest, macos-latest, windows-latest]
         dependencies: [ 'lowest', 'highest' ]
-    continue-on-error: ${{ matrix.os == 'windows-latest' && matrix.php != '8.1' }}
     name: PHP ${{ matrix.php }} - OS ${{ matrix.os }} - Dependencies ${{ matrix.dependencies }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
 name: main
 
 on:
+  push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/tests/Integration/CommandTestCase.php
+++ b/tests/Integration/CommandTestCase.php
@@ -14,7 +14,7 @@ abstract class CommandTestCase extends TestCase
 
     protected static function getComposerJson(): array
     {
-        return [
+        $output = [
             'name' => 'test/project',
             'repositories' => [
                 'composer-downloads-plugin' => [
@@ -76,9 +76,7 @@ abstract class CommandTestCase extends TestCase
                     'text' => [
                         'url' => 'http://localhost:8000/archive/text.tar',
                     ],
-                    'image' => [
-                        'url' => 'http://localhost:8000/archive/image.rar',
-                    ],
+
                     'xml' => [
                         'url' => 'http://localhost:8000/archive/empty.xml.gz',
                         'path' => 'files/markup/empty.xml',
@@ -100,6 +98,14 @@ abstract class CommandTestCase extends TestCase
                 'secure-http' => false,
             ],
         ];
+        // TODO: work out how to support RAR on newer windows
+        if (\PHP_OS_FAMILY !== 'Windows' || (\PHP_OS_FAMILY === 'Windows' && version_compare(\PHP_VERSION, '8.2.0', '<'))) {
+            $output['extra']['downloads']['image'] = [
+                'url' => 'http://localhost:8000/archive/image.rar',
+            ];
+        }
+
+        return $output;
     }
 
     public static function setUpBeforeClass(): void
@@ -128,7 +134,7 @@ abstract class CommandTestCase extends TestCase
 
     protected function getFilesFromProject(): array
     {
-        return [
+        $output = [
             // From project
             'files/phar/hello' => '66ef5d9bd7854d96e0c3b05e8c169a5fbd398ece5299032c132387edb87cf491',
             'files/phar/hello.bat' => \PHP_OS_FAMILY === 'Windows',
@@ -148,15 +154,21 @@ abstract class CommandTestCase extends TestCase
             'files/text/empty.csv' => 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
             'files/text/empty.json' => 'ca3d163bab055381827226140568f3bef7eaac187cebd76878e0b63e9e442356',
             'files/text/empty.txt' => 'b42f2099187886def637d6aa840022266e05cb6c987a9394e708e23cd505eb46',
-            'files/image/empty.bmp' => '1a011d90fff8ac4b581f95472633c311a50143ba5e1020fcd9d578fe921d7c99',
-            'files/image/empty.gif' => '84f7a1205ca382c044859ada51473fda5d972083f0ab5caf0e61309e2fbbc5d1',
-            'files/image/empty.jpg' => 'dc0918fcf7dc57eaef1b0bb69bc1b88e1d10422a38e367565e001306407e41ac',
-            'files/image/empty.png' => '2024896e28f508d6b695fffad2531a2718c1e46b6c2c924d9b77f10ac2688793',
             'files/markup/empty.html' => '5e2ab2f655e9378fd1e54a4bfd81cece72a3bdeb04c87be86041962fe5c3bd3c',
             'files/markup/empty.xml' => '4be690ad5983b2a40f640481fdb27dcc43ac162e14fa9aab2ff45775521d9213',
             'vendor/bin/hello' => false,
             'vendor/bin/hello.bat' => false,
         ];
+
+        // TODO: work out how to support RAR on newer windows
+        if (\PHP_OS_FAMILY !== 'Windows' || (\PHP_OS_FAMILY === 'Windows' && version_compare(\PHP_VERSION, '8.2.0', '<'))) {
+            $output['files/image/empty.bmp'] = '1a011d90fff8ac4b581f95472633c311a50143ba5e1020fcd9d578fe921d7c99';
+            $output['files/image/empty.gif'] = '84f7a1205ca382c044859ada51473fda5d972083f0ab5caf0e61309e2fbbc5d1';
+            $output['files/image/empty.jpg'] = 'dc0918fcf7dc57eaef1b0bb69bc1b88e1d10422a38e367565e001306407e41ac';
+            $output['files/image/empty.png'] = '2024896e28f508d6b695fffad2531a2718c1e46b6c2c924d9b77f10ac2688793';
+        }
+
+        return $output;
     }
 
     protected function getFilesFromLibrary(): array


### PR DESCRIPTION
Bypass failing rar check for windows on 8.2+

All other matricies build and test this.