### PR TITLE
feat: Validate downloaded file

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ Suppose your PHP package `foo/bar` relies on an external archive file (`examplel
             "{$architecture}": "strtolower(php_uname('m'))",
             "{$extension}": "PHP_OS_FAMILY === 'Windows' ? 'zip' : 'tar.gz'",
         },
-        "ignore": ["tests", "doc", "*.md"]
+        "ignore": ["tests", "doc", "*.md"],
+        "hash": {
+          "algo": "sha256",
+          "value": "08fbce50f84d89fdf1fdef425c7dd1a13c5c023fa87f453ba77db4df27d273c0"
+        }
       }
     }
   }
@@ -67,6 +71,10 @@ When a downstream user of `foo/bar` runs `composer require foo/bar`, it will dow
   * It can be used as a variable.
 
 * `variables`: (*Optional*) List of custom variables.
+
+* `hash`: (*Optional*) Verify contents of the file downloaded from `url`. If hash values are not the same: file will be **deleted** & composer will **throw exception**.
+  * `algo`: Name of selected hashing algorithm (i.e. "md5", "sha256", "haval160,4", etc..). For a list of supported algorithms see `hash_algos()`
+  * `value`: Expected value of hash function
 
 ## Variables
 

--- a/src/Exception/BaseException.php
+++ b/src/Exception/BaseException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Exception;
+
+class BaseException extends \Exception
+{
+}

--- a/src/Exception/InvalidDownloadedFileException.php
+++ b/src/Exception/InvalidDownloadedFileException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Exception;
+
+class InvalidDownloadedFileException extends BaseException
+{
+}

--- a/src/Filter/FilterManager.php
+++ b/src/Filter/FilterManager.php
@@ -14,6 +14,7 @@ class FilterManager
     public const VERSION = 'version';
     public const EXECUTABLE = 'executable';
     public const IGNORE = 'ignore';
+    public const HASH = 'hash';
 
     private array $filters;
 
@@ -30,6 +31,7 @@ class FilterManager
             self::TYPE => $typeFilter = new TypeFilter($subpackageName, $parent, $urlFilter),
             self::EXECUTABLE => new ExecutableFilter($subpackageName, $parent, $parentPath, $typeFilter, $pathFilter),
             self::IGNORE => new IgnoreFilter($subpackageName, $parent, $typeFilter, $variablesFilter),
+            self::HASH => new HashFilter($subpackageName, $parent),
         ];
     }
 

--- a/src/Filter/HashFilter.php
+++ b/src/Filter/HashFilter.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Filter;
+
+use Composer\Package\PackageInterface;
+use LastCall\DownloadsPlugin\Model\Hash;
+
+class HashFilter extends BaseFilter
+{
+    public function __construct(
+        string $subpackageName,
+        PackageInterface $parent,
+    ) {
+        parent::__construct($subpackageName, $parent);
+    }
+
+    protected function get(array $extraFile): ?Hash
+    {
+        if (isset($extraFile['hash'])) {
+            $hash = $extraFile['hash'];
+            if (!\is_array($hash)) {
+                $this->throwException('hash', sprintf('must be array, "%s" given', get_debug_type($hash)));
+            }
+
+            $algo = $hash['algo'] ?? null;
+            if (!\is_string($algo)) {
+                $this->throwException('hash > algo', sprintf('must be string, "%s" given', get_debug_type($algo)));
+            }
+
+            if (!\in_array($algo, hash_algos(), true)) {
+                $this->throwException('hash > algo', 'is not supported');
+            }
+
+            $value = $hash['value'] ?? null;
+            if (!\is_string($value)) {
+                $this->throwException('hash > value', sprintf('must be string, "%s" given', get_debug_type($value)));
+            }
+
+            return new Hash($algo, $value);
+        }
+
+        return null;
+    }
+}

--- a/src/Handler/ArchiveHandler.php
+++ b/src/Handler/ArchiveHandler.php
@@ -47,16 +47,11 @@ abstract class ArchiveHandler extends BaseHandler
         return ['ignore' => $ignore] + parent::getChecksumData();
     }
 
-    public function install(Composer $composer, IOInterface $io): void
+    protected function handleDownloadedFile(Composer $composer, IOInterface $io, string $file): void
     {
-        $file = $this->download($composer);
-        if ($this->validateDownloadedFile($file)) {
-            $this->extract($composer, $this->subpackage->getTargetPath());
-            $this->clean();
-            $this->installBinaries($composer, $io);
-        } else {
-            $this->handleInvalidDownloadedFile($file);
-        }
+        $this->extract($composer, $this->subpackage->getTargetPath());
+        $this->clean();
+        $this->installBinaries($composer, $io);
     }
 
     private function clean(): void

--- a/src/Handler/ArchiveHandler.php
+++ b/src/Handler/ArchiveHandler.php
@@ -3,7 +3,6 @@
 namespace LastCall\DownloadsPlugin\Handler;
 
 use Composer\Composer;
-use Composer\IO\IOInterface;
 use Composer\Util\Filesystem;
 use LastCall\DownloadsPlugin\BinariesInstaller;
 use LastCall\DownloadsPlugin\GlobCleaner;
@@ -47,11 +46,10 @@ abstract class ArchiveHandler extends BaseHandler
         return ['ignore' => $ignore] + parent::getChecksumData();
     }
 
-    protected function handleDownloadedFile(Composer $composer, IOInterface $io, string $file): void
+    protected function handleDownloadedFile(Composer $composer, string $file): void
     {
         $this->extract($composer, $this->subpackage->getTargetPath());
         $this->clean();
-        $this->installBinaries($io);
     }
 
     private function clean(): void

--- a/src/Handler/ArchiveHandler.php
+++ b/src/Handler/ArchiveHandler.php
@@ -51,7 +51,7 @@ abstract class ArchiveHandler extends BaseHandler
     {
         $this->extract($composer, $this->subpackage->getTargetPath());
         $this->clean();
-        $this->installBinaries($composer, $io);
+        $this->installBinaries($io);
     }
 
     private function clean(): void

--- a/src/Handler/BaseHandler.php
+++ b/src/Handler/BaseHandler.php
@@ -78,7 +78,7 @@ abstract class BaseHandler implements HandlerInterface
 
     abstract protected function handleDownloadedFile(Composer $composer, IOInterface $io, string $file): void;
 
-    protected function installBinaries(Composer $composer, IOInterface $io): void
+    protected function installBinaries(IOInterface $io): void
     {
         $this->binariesInstaller->install($this->subpackage, $io);
     }

--- a/src/Handler/BaseHandler.php
+++ b/src/Handler/BaseHandler.php
@@ -70,15 +70,16 @@ abstract class BaseHandler implements HandlerInterface
     {
         $file = $this->download($composer);
         if ($this->validateDownloadedFile($file)) {
-            $this->handleDownloadedFile($composer, $io, $file);
+            $this->handleDownloadedFile($composer, $file);
+            $this->installBinaries($io);
         } else {
             $this->handleInvalidDownloadedFile($file);
         }
     }
 
-    abstract protected function handleDownloadedFile(Composer $composer, IOInterface $io, string $file): void;
+    abstract protected function handleDownloadedFile(Composer $composer, string $file): void;
 
-    protected function installBinaries(IOInterface $io): void
+    private function installBinaries(IOInterface $io): void
     {
         $this->binariesInstaller->install($this->subpackage, $io);
     }

--- a/src/Handler/BaseHandler.php
+++ b/src/Handler/BaseHandler.php
@@ -66,6 +66,18 @@ abstract class BaseHandler implements HandlerInterface
         ];
     }
 
+    public function install(Composer $composer, IOInterface $io): void
+    {
+        $file = $this->download($composer);
+        if ($this->validateDownloadedFile($file)) {
+            $this->handleDownloadedFile($composer, $io, $file);
+        } else {
+            $this->handleInvalidDownloadedFile($file);
+        }
+    }
+
+    abstract protected function handleDownloadedFile(Composer $composer, IOInterface $io, string $file): void;
+
     protected function installBinaries(Composer $composer, IOInterface $io): void
     {
         $this->binariesInstaller->install($this->subpackage, $io);
@@ -74,7 +86,7 @@ abstract class BaseHandler implements HandlerInterface
     /**
      * Download file to temporary place ("vendor/composer/tmp-[random-file-name]"), return downloaded file's path.
      */
-    protected function download(Composer $composer): string
+    private function download(Composer $composer): string
     {
         $downloadManager = $composer->getDownloadManager();
 
@@ -90,7 +102,7 @@ abstract class BaseHandler implements HandlerInterface
         return $file;
     }
 
-    protected function validateDownloadedFile(string $filePath): bool
+    private function validateDownloadedFile(string $filePath): bool
     {
         $hash = $this->subpackage->getHash();
 
@@ -122,7 +134,7 @@ abstract class BaseHandler implements HandlerInterface
         $composer->getLoop()->wait([$promise]);
     }
 
-    protected function handleInvalidDownloadedFile(string $file): void
+    private function handleInvalidDownloadedFile(string $file): void
     {
         $this->remove($file);
         throw new InvalidDownloadedFileException(sprintf('Extra file "%s" does not match hash value defined in "%s".', $this->subpackage->getDistUrl(), $this->subpackage->getSubpackageName()));

--- a/src/Handler/FileHandler.php
+++ b/src/Handler/FileHandler.php
@@ -23,6 +23,6 @@ class FileHandler extends BaseHandler
     protected function handleDownloadedFile(Composer $composer, IOInterface $io, string $file): void
     {
         $this->move($file);
-        $this->installBinaries($composer, $io);
+        $this->installBinaries($io);
     }
 }

--- a/src/Handler/FileHandler.php
+++ b/src/Handler/FileHandler.php
@@ -4,24 +4,10 @@ namespace LastCall\DownloadsPlugin\Handler;
 
 use Composer\Composer;
 use Composer\IO\IOInterface;
-use Composer\Util\Filesystem;
-use LastCall\DownloadsPlugin\BinariesInstaller;
-use LastCall\DownloadsPlugin\Subpackage;
 
 class FileHandler extends BaseHandler
 {
     public const TMP_PREFIX = '.composer-extra-tmp-';
-
-    protected Filesystem $filesystem;
-
-    public function __construct(
-        Subpackage $subpackage,
-        ?BinariesInstaller $binariesInstaller = null,
-        ?Filesystem $filesystem = null
-    ) {
-        parent::__construct($subpackage, $binariesInstaller);
-        $this->filesystem = $filesystem ?? new Filesystem();
-    }
 
     public function getTrackingFile(): string
     {
@@ -34,25 +20,16 @@ class FileHandler extends BaseHandler
             \DIRECTORY_SEPARATOR.$file;
     }
 
-    protected function download(Composer $composer, IOInterface $io): void
+    public function install(Composer $composer, IOInterface $io): void
     {
         // We want to take advantage of the cache in composer's downloader, but it
         // doesn't put the file the spot we want, so we shuffle a bit.
-
-        $target = $this->subpackage->getTargetPath();
-        $downloadManager = $composer->getDownloadManager();
-
-        $file = '';
-        $promise = $downloadManager->download($this->subpackage, \dirname($target));
-        $promise->then(static function ($res) use (&$file) {
-            $file = $res;
-
-            return \React\Promise\resolve($res);
-        });
-        $composer->getLoop()->wait([$promise]);
-        // Look like Composer v2 doesn't care about $target above.
-        // It download the file to "vendor/composer/tmp-[random-file-name]"
-        // We need to move the file to where we want.
-        $this->filesystem->rename($file, $target);
+        $file = $this->download($composer);
+        if ($this->validateDownloadedFile($file)) {
+            $this->move($file);
+            $this->installBinaries($composer, $io);
+        } else {
+            $this->handleInvalidDownloadedFile($file);
+        }
     }
 }

--- a/src/Handler/FileHandler.php
+++ b/src/Handler/FileHandler.php
@@ -3,7 +3,6 @@
 namespace LastCall\DownloadsPlugin\Handler;
 
 use Composer\Composer;
-use Composer\IO\IOInterface;
 
 class FileHandler extends BaseHandler
 {
@@ -20,9 +19,8 @@ class FileHandler extends BaseHandler
             \DIRECTORY_SEPARATOR.$file;
     }
 
-    protected function handleDownloadedFile(Composer $composer, IOInterface $io, string $file): void
+    protected function handleDownloadedFile(Composer $composer, string $file): void
     {
         $this->move($file);
-        $this->installBinaries($io);
     }
 }

--- a/src/Handler/FileHandler.php
+++ b/src/Handler/FileHandler.php
@@ -20,16 +20,9 @@ class FileHandler extends BaseHandler
             \DIRECTORY_SEPARATOR.$file;
     }
 
-    public function install(Composer $composer, IOInterface $io): void
+    protected function handleDownloadedFile(Composer $composer, IOInterface $io, string $file): void
     {
-        // We want to take advantage of the cache in composer's downloader, but it
-        // doesn't put the file the spot we want, so we shuffle a bit.
-        $file = $this->download($composer);
-        if ($this->validateDownloadedFile($file)) {
-            $this->move($file);
-            $this->installBinaries($composer, $io);
-        } else {
-            $this->handleInvalidDownloadedFile($file);
-        }
+        $this->move($file);
+        $this->installBinaries($composer, $io);
     }
 }

--- a/src/Handler/GzipHandler.php
+++ b/src/Handler/GzipHandler.php
@@ -14,7 +14,7 @@ class GzipHandler extends FileHandler
 
         $this->extract($composer, $tmpDir);
         $this->move($tmpDir.\DIRECTORY_SEPARATOR.$targetName);
-        $this->installBinaries($composer, $io);
+        $this->installBinaries($io);
         $this->remove($tmpDir);
     }
 }

--- a/src/Handler/GzipHandler.php
+++ b/src/Handler/GzipHandler.php
@@ -7,20 +7,14 @@ use Composer\IO\IOInterface;
 
 class GzipHandler extends FileHandler
 {
-    public function install(Composer $composer, IOInterface $io): void
+    protected function handleDownloadedFile(Composer $composer, IOInterface $io, string $file): void
     {
         $tmpDir = \dirname($this->subpackage->getTargetPath()).\DIRECTORY_SEPARATOR.uniqid(self::TMP_PREFIX, true);
         $targetName = pathinfo($this->subpackage->getDistUrl(), \PATHINFO_FILENAME);
-        $filePath = $tmpDir.\DIRECTORY_SEPARATOR.$targetName;
 
-        $file = $this->download($composer);
-        if ($this->validateDownloadedFile($file)) {
-            $this->extract($composer, $tmpDir);
-            $this->move($filePath);
-            $this->installBinaries($composer, $io);
-            $this->remove($tmpDir);
-        } else {
-            $this->handleInvalidDownloadedFile($file);
-        }
+        $this->extract($composer, $tmpDir);
+        $this->move($tmpDir.\DIRECTORY_SEPARATOR.$targetName);
+        $this->installBinaries($composer, $io);
+        $this->remove($tmpDir);
     }
 }

--- a/src/Handler/GzipHandler.php
+++ b/src/Handler/GzipHandler.php
@@ -3,18 +3,16 @@
 namespace LastCall\DownloadsPlugin\Handler;
 
 use Composer\Composer;
-use Composer\IO\IOInterface;
 
 class GzipHandler extends FileHandler
 {
-    protected function handleDownloadedFile(Composer $composer, IOInterface $io, string $file): void
+    protected function handleDownloadedFile(Composer $composer, string $file): void
     {
         $tmpDir = \dirname($this->subpackage->getTargetPath()).\DIRECTORY_SEPARATOR.uniqid(self::TMP_PREFIX, true);
         $targetName = pathinfo($this->subpackage->getDistUrl(), \PATHINFO_FILENAME);
 
         $this->extract($composer, $tmpDir);
         $this->move($tmpDir.\DIRECTORY_SEPARATOR.$targetName);
-        $this->installBinaries($io);
         $this->remove($tmpDir);
     }
 }

--- a/src/Model/Hash.php
+++ b/src/Model/Hash.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Model;
+
+class Hash
+{
+    public function __construct(public readonly string $algo, public readonly string $value)
+    {
+    }
+}

--- a/src/Subpackage.php
+++ b/src/Subpackage.php
@@ -13,6 +13,7 @@ namespace LastCall\DownloadsPlugin;
 
 use Composer\Package\Package;
 use Composer\Package\PackageInterface;
+use LastCall\DownloadsPlugin\Model\Hash;
 use LastCall\DownloadsPlugin\Model\Version;
 
 /**
@@ -30,6 +31,7 @@ class Subpackage extends Package
         string $url,
         string $path,
         Version $version,
+        private ?Hash $hash = null,
     ) {
         parent::__construct(
             sprintf('%s:%s', $parent->getName(), $subpackageName),
@@ -70,5 +72,15 @@ class Subpackage extends Package
     public function getSubpackageType(): string
     {
         return $this->subpackageType;
+    }
+
+    public function setHash(?Hash $hash): void
+    {
+        $this->hash = $hash;
+    }
+
+    public function getHash(): ?Hash
+    {
+        return $this->hash;
     }
 }

--- a/src/SubpackageFactory.php
+++ b/src/SubpackageFactory.php
@@ -25,6 +25,7 @@ class SubpackageFactory
         $path = $filterManager->get(FilterManager::PATH)->filter($extraFile);
         $version = $filterManager->get(FilterManager::VERSION)->filter($extraFile);
         $type = $filterManager->get(FilterManager::TYPE)->filter($extraFile);
+        $hash = $filterManager->get(FilterManager::HASH)->filter($extraFile);
 
         return new Subpackage(
             $parent,
@@ -36,6 +37,7 @@ class SubpackageFactory
             $url,
             $path,
             $version,
+            $hash
         );
     }
 

--- a/tests/Integration/Hash/InvalidDownloadedFileTest.php
+++ b/tests/Integration/Hash/InvalidDownloadedFileTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Tests\Integration\Hash;
+
+use LastCall\DownloadsPlugin\Tests\Integration\CommandTestCase;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+class InvalidDownloadedFileTest extends CommandTestCase
+{
+    protected static function getComposerJson(): array
+    {
+        $output = parent::getComposerJson();
+        unset($output['require']['test/library']);
+        $output['extra']['downloads'] = [
+            'file' => [
+                'type' => 'phar',
+                'url' => 'http://localhost:8000/phar/hello.phar',
+                'path' => 'files/file',
+                'hash' => [
+                    'algo' => 'md5',
+                    'value' => 'not-correct',
+                ],
+            ],
+            'archive' => [
+                'url' => 'http://localhost:8000/archive/doc/v1.2.3/doc.zip',
+                'path' => 'files/archive',
+                'hash' => [
+                    'algo' => 'sha256',
+                    'value' => 'not-correct',
+                ],
+            ],
+            'gzip' => [
+                'url' => 'http://localhost:8000/archive/empty.xml.gz',
+                'path' => 'files/gzip',
+                'hash' => [
+                    'algo' => 'sha512',
+                    'value' => 'not-correct',
+                ],
+            ],
+        ];
+
+        return $output;
+    }
+
+    protected function getFiles(): array
+    {
+        return [
+            'files/file' => false,
+            'files/archive/empty.doc' => false,
+            'files/archive/empty.docx' => false,
+            'files/gzip' => false,
+        ];
+    }
+
+    protected function getExecutableFiles(): array
+    {
+        return [];
+    }
+
+    public function testDownload(): void
+    {
+        $this->expectException(ProcessFailedException::class);
+        $this->runComposerCommandAndAssert(['install']);
+    }
+}

--- a/tests/Integration/Hash/ValidDownloadedFileTest.php
+++ b/tests/Integration/Hash/ValidDownloadedFileTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Tests\Integration\Hash;
+
+use LastCall\DownloadsPlugin\Tests\Integration\CommandTestCase;
+
+class ValidDownloadedFileTest extends CommandTestCase
+{
+    protected static function getComposerJson(): array
+    {
+        $output = parent::getComposerJson();
+        unset($output['require']['test/library']);
+        $output['extra']['downloads'] = [
+            'file' => [
+                'type' => 'phar',
+                'url' => 'http://localhost:8000/phar/hello.phar',
+                'path' => 'files/file',
+                'hash' => [
+                    'algo' => 'md5',
+                    'value' => '03df6683864fe411969b403b772fbf97',
+                ],
+            ],
+            'archive' => [
+                'url' => 'http://localhost:8000/archive/doc/v1.2.3/doc.zip',
+                'path' => 'files/archive',
+                'hash' => [
+                    'algo' => 'sha256',
+                    'value' => 'bd55e83aafb4405901e6f6ce516aca807661dde6ffde451d8e3fea97e39a8be5',
+                ],
+            ],
+            'gzip' => [
+                'url' => 'http://localhost:8000/archive/empty.xml.gz',
+                'path' => 'files/gzip',
+                'hash' => [
+                    'algo' => 'sha512',
+                    'value' => '8ef8a07339dbc2fec220f14e49af5c606ce0667fd2528ea6c8da9bd757ee6cfec2d94823205372c972b4ebd52d86cde66d549a5a4fe7a73de227f6ae1a4b0a82',
+                ],
+            ],
+        ];
+
+        return $output;
+    }
+
+    protected function getFiles(): array
+    {
+        return [
+            'files/file' => '66ef5d9bd7854d96e0c3b05e8c169a5fbd398ece5299032c132387edb87cf491',
+            'files/archive/empty.doc' => '60b5e45db3b51c38a5b762e771ee2f19692f52186c42c3930d56bbdf04d21f4e',
+            'files/archive/empty.docx' => '61cdb4b8b9067ab1f4eaa5ba782007c81bdd04283a228b5076aeeb4c9362020b',
+            'files/gzip' => '4be690ad5983b2a40f640481fdb27dcc43ac162e14fa9aab2ff45775521d9213',
+        ];
+    }
+
+    protected function getExecutableFiles(): array
+    {
+        return [];
+    }
+
+    public function testDownload(): void
+    {
+        $this->runComposerCommandAndAssert(['install']);
+    }
+}

--- a/tests/Integration/Invalid/InvalidHashAlgoTest.php
+++ b/tests/Integration/Invalid/InvalidHashAlgoTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Tests\Integration\Invalid;
+
+class InvalidHashAlgoTest extends InstallInvalidExtraDownloadsTest
+{
+    protected static function getId(): string
+    {
+        return 'invalid-hash-algo';
+    }
+
+    protected static function getExtraFile(): array
+    {
+        return [
+            'path' => 'files/invalid/hash',
+            'url' => 'http://localhost:8000/file/ipsum',
+            'hash' => [
+                'algo' => 'invalid',
+            ],
+        ];
+    }
+
+    protected static function getErrorMessage(): string
+    {
+        return 'Skipped download extra files for package test/project: Attribute "hash > algo" of extra file "invalid-hash-algo" defined in package "test/project" is not supported.';
+    }
+}

--- a/tests/Integration/Invalid/InvalidHashTest.php
+++ b/tests/Integration/Invalid/InvalidHashTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Tests\Integration\Invalid;
+
+class InvalidHashTest extends InstallInvalidExtraDownloadsTest
+{
+    protected static function getId(): string
+    {
+        return 'invalid-hash';
+    }
+
+    protected static function getExtraFile(): array
+    {
+        return [
+            'path' => 'files/invalid/hash',
+            'url' => 'http://localhost:8000/file/ipsum',
+            'hash' => 'e86186d2b34630a05ead6cff9d29c5c3',
+        ];
+    }
+
+    protected static function getErrorMessage(): string
+    {
+        return 'Skipped download extra files for package test/project: Attribute "hash" of extra file "invalid-hash" defined in package "test/project" must be array, "string" given.';
+    }
+}

--- a/tests/Integration/Invalid/InvalidHashValueTest.php
+++ b/tests/Integration/Invalid/InvalidHashValueTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Tests\Integration\Invalid;
+
+class InvalidHashValueTest extends InstallInvalidExtraDownloadsTest
+{
+    protected static function getId(): string
+    {
+        return 'invalid-hash-value';
+    }
+
+    protected static function getExtraFile(): array
+    {
+        return [
+            'path' => 'files/invalid/hash',
+            'url' => 'http://localhost:8000/file/ipsum',
+            'hash' => [
+                'algo' => 'md5',
+                'value' => [
+                    'key' => 'value',
+                ],
+            ],
+        ];
+    }
+
+    protected static function getErrorMessage(): string
+    {
+        return 'Skipped download extra files for package test/project: Attribute "hash > value" of extra file "invalid-hash-value" defined in package "test/project" must be string, "array" given.';
+    }
+}

--- a/tests/Unit/Filter/FilterManagerTest.php
+++ b/tests/Unit/Filter/FilterManagerTest.php
@@ -6,6 +6,7 @@ use Composer\Package\PackageInterface;
 use LastCall\DownloadsPlugin\Exception\OutOfRangeException;
 use LastCall\DownloadsPlugin\Filter\ExecutableFilter;
 use LastCall\DownloadsPlugin\Filter\FilterManager;
+use LastCall\DownloadsPlugin\Filter\HashFilter;
 use LastCall\DownloadsPlugin\Filter\IgnoreFilter;
 use LastCall\DownloadsPlugin\Filter\PathFilter;
 use LastCall\DownloadsPlugin\Filter\TypeFilter;
@@ -38,6 +39,7 @@ class FilterManagerTest extends TestCase
             ['executable', ExecutableFilter::class],
             ['ignore', IgnoreFilter::class],
             ['type', TypeFilter::class],
+            ['hash', HashFilter::class],
         ];
     }
 

--- a/tests/Unit/Filter/HashFilterTest.php
+++ b/tests/Unit/Filter/HashFilterTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Tests\Unit\Filter;
+
+use LastCall\DownloadsPlugin\Filter\FilterInterface;
+use LastCall\DownloadsPlugin\Filter\HashFilter;
+
+class HashFilterTest extends BaseFilterTestCase
+{
+    private string $version = '1.2.3.0';
+    private string $prettyVersion = 'v1.2.3';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function getInvalidHashTests(): array
+    {
+        return [
+            [true, 'bool'],
+            [false, 'bool'],
+            [123, 'int'],
+            [12.3, 'float'],
+            ['test', 'string'],
+            [(object) ['key' => 'value'], 'stdClass'],
+        ];
+    }
+
+    /**
+     * @dataProvider getInvalidHashTests
+     */
+    public function testInvalidHash(mixed $invalidHash, string $type): void
+    {
+        $this->parent->expects($this->once())->method('getName')->willReturn($this->parentName);
+        $this->expectUnexpectedValueException('hash', sprintf('must be array, "%s" given', $type));
+        $this->filter->filter([
+            'hash' => $invalidHash,
+        ]);
+    }
+
+    public function getInvalidHashChildTests(): array
+    {
+        return [
+            [true, 'bool'],
+            [false, 'bool'],
+            [123, 'int'],
+            [12.3, 'float'],
+            [['key' => 'value'], 'array'],
+            [(object) ['key' => 'value'], 'stdClass'],
+        ];
+    }
+
+    /**
+     * @dataProvider getInvalidHashChildTests
+     */
+    public function testInvalidAlgo(mixed $invalidAlgo, string $type): void
+    {
+        $this->parent->expects($this->once())->method('getName')->willReturn($this->parentName);
+        $this->expectUnexpectedValueException('hash > algo', sprintf('must be string, "%s" given', $type));
+        $this->filter->filter([
+            'hash' => [
+                'algo' => $invalidAlgo,
+                'value' => 'abc123',
+            ],
+        ]);
+    }
+
+    public function testNotSupportedAlgo(): void
+    {
+        $this->parent->expects($this->once())->method('getName')->willReturn($this->parentName);
+        $this->expectUnexpectedValueException('hash > algo', 'is not supported');
+        $this->filter->filter([
+            'hash' => [
+                'algo' => 'not-supported',
+                'value' => 'abc123',
+            ],
+        ]);
+    }
+
+    /**
+     * @dataProvider getInvalidHashChildTests
+     */
+    public function testInvalidValue(mixed $invalidValue, string $type): void
+    {
+        $this->parent->expects($this->once())->method('getName')->willReturn($this->parentName);
+        $this->expectUnexpectedValueException('hash > value', sprintf('must be string, "%s" given', $type));
+        $this->filter->filter([
+            'hash' => [
+                'algo' => 'md5',
+                'value' => $invalidValue,
+            ],
+        ]);
+    }
+
+    public function testValidHash(): void
+    {
+        $hash = $this->filter->filter([
+            'hash' => [
+                'algo' => $expectedAlgo = 'sha256',
+                'value' => $expectedValue = '1d0f9d464f7330e866357380d76f5f68becf0ca84b205a2135fd392581ed0b1d',
+            ],
+        ]);
+        $this->assertSame($expectedAlgo, $hash->algo);
+        $this->assertSame($expectedValue, $hash->value);
+    }
+
+    protected function createFilter(): FilterInterface
+    {
+        return new HashFilter($this->name, $this->parent);
+    }
+}

--- a/tests/Unit/Handler/BaseHandlerTestCase.php
+++ b/tests/Unit/Handler/BaseHandlerTestCase.php
@@ -6,26 +6,32 @@ use Composer\Composer;
 use Composer\Downloader\DownloadManager;
 use Composer\IO\IOInterface;
 use Composer\Package\Package;
+use Composer\Util\Filesystem;
 use Composer\Util\Loop;
 use LastCall\DownloadsPlugin\BinariesInstaller;
+use LastCall\DownloadsPlugin\Exception\InvalidDownloadedFileException;
 use LastCall\DownloadsPlugin\Handler\HandlerInterface;
+use LastCall\DownloadsPlugin\Model\Hash;
 use LastCall\DownloadsPlugin\Model\Version;
 use LastCall\DownloadsPlugin\Subpackage;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use React\Promise\PromiseInterface;
+use VirtualFileSystem\FileSystem as VirtualFileSystem;
 
 abstract class BaseHandlerTestCase extends TestCase
 {
+    private ?VirtualFileSystem $fs = null;
     protected Composer|MockObject $composer;
-    private IOInterface|MockObject $io;
+    protected IOInterface|MockObject $io;
     protected DownloadManager|MockObject $downloadManager;
     private BinariesInstaller|MockObject $binariesInstaller;
     protected PromiseInterface|MockObject $downloadPromise;
     protected PromiseInterface|MockObject $installPromise;
     protected Loop|MockObject $loop;
-    private Subpackage $subpackage;
-    private HandlerInterface $handler;
+    protected Filesystem|MockObject $filesystem;
+    protected Subpackage $subpackage;
+    protected HandlerInterface $handler;
     private string $parentPath = '/path/to/package';
     protected string $id = 'sub-package-name';
     protected string $url = 'http://example.com/file.ext';
@@ -34,9 +40,11 @@ abstract class BaseHandlerTestCase extends TestCase
     protected string $targetPath;
     protected array $ignore = ['file.*', '!file.ext'];
     protected string $parentName = 'vendor/parent-package';
+    private string $tmpFile = '/path/to/vendor/composer/tmp-random';
 
     protected function setUp(): void
     {
+        $this->fs = new VirtualFileSystem(); // Keep virtual file system alive during test
         $this->composer = $this->createMock(Composer::class);
         $this->io = $this->createMock(IOInterface::class);
         $this->downloadManager = $this->createMock(DownloadManager::class);
@@ -44,6 +52,7 @@ abstract class BaseHandlerTestCase extends TestCase
         $this->downloadPromise = $this->createMock(PromiseInterface::class);
         $this->installPromise = $this->createMock(PromiseInterface::class);
         $this->loop = $this->createMock(Loop::class);
+        $this->filesystem = $this->createMock(Filesystem::class);
         $this->extraFile = [
             'id' => $this->id,
             'url' => $this->url,
@@ -62,6 +71,11 @@ abstract class BaseHandlerTestCase extends TestCase
             new Version('1.2.3.0', 'v1.2.3'),
         );
         $this->handler = $this->createHandler();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->fs = null;
     }
 
     public function testGetSubpackage(): void
@@ -84,26 +98,66 @@ abstract class BaseHandlerTestCase extends TestCase
         $this->assertSame($this->getTrackingFile(), $this->handler->getTrackingFile());
     }
 
-    public function testInstall(): void
-    {
-        $this->assertDownload();
-        $this->assertBinariesInstaller();
-        $this->handler->install($this->composer, $this->io);
-    }
-
-    protected function assertBinariesInstaller(): void
+    protected function assertBinariesInstaller(bool $isValid): void
     {
         $this->binariesInstaller
-            ->expects($this->once())
+            ->expects($this->exactly($isValid))
             ->method('install')
             ->with($this->isInstanceOf(Subpackage::class), $this->io);
     }
 
-    abstract protected function assertDownload(): void;
+    protected function assertDownload(): void
+    {
+        $this->composer->expects($this->any())->method('getDownloadManager')->willReturn($this->downloadManager);
+        $this->downloadPromise
+            ->expects($this->once())
+            ->method('then')
+            ->willReturnCallback(fn (callable $callback) => $callback($this->getTmpFilePath()));
+        $this->downloadManager
+            ->expects($this->once())
+            ->method('download')
+            ->with($this->subpackage, \dirname($this->targetPath))
+            ->willReturn($this->downloadPromise);
+        $this->loop
+            ->expects($this->at(0))
+            ->method('wait')
+            ->with([$this->downloadPromise]);
+        $this->composer->expects($this->any())->method('getLoop')->willReturn($this->loop);
+    }
+
+    protected function assertValidateDownloadedFile(bool $hasHash, bool $isValid): void
+    {
+        $this->fs->createDirectory(\dirname($this->tmpFile), true);
+        $this->fs->createFile($this->tmpFile, $content = 'hello world');
+        if ($hasHash) {
+            $this->subpackage->setHash(new Hash('md5', $isValid ? md5($content) : 'not valid'));
+        } else {
+            $this->subpackage->setHash(null);
+        }
+    }
+
+    protected function assertRemoveDownloadedFile(bool $isValid): void
+    {
+        $this->filesystem
+            ->expects($this->exactly(!$isValid))
+            ->method('remove')
+            ->with($this->getTmpFilePath());
+    }
+
+    protected function expectInvalidDownloadedFileException(bool $isValid): void
+    {
+        if (!$isValid) {
+            $this->expectException(InvalidDownloadedFileException::class);
+            $this->expectExceptionMessage(sprintf('Extra file "%s" does not match hash value defined in "%s".', $this->url, $this->id));
+        }
+    }
 
     abstract protected function getHandlerClass(): string;
 
-    abstract protected function getHandlerExtraArguments(): array;
+    protected function getHandlerExtraArguments(): array
+    {
+        return [];
+    }
 
     abstract protected function getTrackingFile(): string;
 
@@ -119,6 +173,11 @@ abstract class BaseHandlerTestCase extends TestCase
     {
         $class = $this->getHandlerClass();
 
-        return new $class($this->subpackage, $this->binariesInstaller, ...$this->getHandlerExtraArguments());
+        return new $class($this->subpackage, $this->binariesInstaller, $this->filesystem, ...$this->getHandlerExtraArguments());
+    }
+
+    protected function getTmpFilePath(): string
+    {
+        return $this->fs->path($this->tmpFile);
     }
 }

--- a/tests/Unit/Handler/FileHandlerTest.php
+++ b/tests/Unit/Handler/FileHandlerTest.php
@@ -1,28 +1,11 @@
 <?php
 
-namespace LastCall\DownloadsPlugin\Tests\Unit;
+namespace LastCall\DownloadsPlugin\Tests\Unit\Handler;
 
-use Composer\Util\Filesystem;
 use LastCall\DownloadsPlugin\Handler\FileHandler;
-use LastCall\DownloadsPlugin\Subpackage;
-use LastCall\DownloadsPlugin\Tests\Unit\Handler\BaseHandlerTestCase;
-use PHPUnit\Framework\MockObject\MockObject;
 
 class FileHandlerTest extends BaseHandlerTestCase
 {
-    protected Filesystem|MockObject $filesystem;
-
-    protected function setUp(): void
-    {
-        $this->filesystem = $this->createMock(Filesystem::class);
-        parent::setUp();
-    }
-
-    protected function getHandlerExtraArguments(): array
-    {
-        return [$this->filesystem];
-    }
-
     protected function getTrackingFile(): string
     {
         return \dirname($this->targetPath).\DIRECTORY_SEPARATOR.'.composer-downloads'.\DIRECTORY_SEPARATOR.'sub-package-name-4fcb9a7a2ac376c89d1d147894dca87b.json';
@@ -43,27 +26,6 @@ class FileHandlerTest extends BaseHandlerTestCase
         return 'eb2ddda74e9049129d10e5b75520a374820a3826ca86a99f72a300cfe57320cc';
     }
 
-    protected function assertDownload(): void
-    {
-        $this->composer->expects($this->once())->method('getDownloadManager')->willReturn($this->downloadManager);
-        $tmpFile = '/path/to/vendor/composer/tmp-random';
-        $this->downloadPromise
-            ->expects($this->once())
-            ->method('then')
-            ->willReturnCallback(fn (callable $callback) => $callback($tmpFile));
-        $this->downloadManager
-            ->expects($this->once())
-            ->method('download')
-            ->with($this->isInstanceOf(Subpackage::class), \dirname($this->targetPath))
-            ->willReturn($this->downloadPromise);
-        $this->loop
-            ->expects($this->once())
-            ->method('wait')
-            ->with([$this->downloadPromise]);
-        $this->composer->expects($this->once())->method('getLoop')->willReturn($this->loop);
-        $this->filesystem->expects($this->once())->method('rename')->with($tmpFile, $this->targetPath);
-    }
-
     protected function getExecutableType(): string
     {
         return 'boolean';
@@ -76,5 +38,29 @@ class FileHandlerTest extends BaseHandlerTestCase
             'url' => $this->url,
             'checksum' => $this->getChecksum(),
         ];
+    }
+
+    /**
+     * @testWith [true, true]
+     *           [true, false]
+     *           [false, true]
+     */
+    public function testInstall(bool $hasHash, bool $isValid): void
+    {
+        $this->assertDownload();
+        $this->assertValidateDownloadedFile($hasHash, $isValid);
+        $this->assertBinariesInstaller($isValid);
+        $this->assertMoveDownloadedFile($isValid);
+        $this->assertRemoveDownloadedFile($isValid);
+        $this->expectInvalidDownloadedFileException($isValid);
+        $this->handler->install($this->composer, $this->io);
+    }
+
+    private function assertMoveDownloadedFile(bool $isValid): void
+    {
+        $this->filesystem
+            ->expects($this->exactly($isValid))
+            ->method('rename')
+            ->with($this->getTmpFilePath(), $this->targetPath);
     }
 }

--- a/tests/Unit/Handler/PharHandlerTest.php
+++ b/tests/Unit/Handler/PharHandlerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LastCall\DownloadsPlugin\Tests\Unit;
+namespace LastCall\DownloadsPlugin\Tests\Unit\Handler;
 
 use LastCall\DownloadsPlugin\Handler\PharHandler;
 

--- a/tests/Unit/Handler/RarHandlerTest.php
+++ b/tests/Unit/Handler/RarHandlerTest.php
@@ -1,9 +1,8 @@
 <?php
 
-namespace LastCall\DownloadsPlugin\Tests\Unit;
+namespace LastCall\DownloadsPlugin\Tests\Unit\Handler;
 
 use LastCall\DownloadsPlugin\Handler\RarHandler;
-use LastCall\DownloadsPlugin\Tests\Unit\Handler\ArchiveHandlerTestCase;
 
 class RarHandlerTest extends ArchiveHandlerTestCase
 {

--- a/tests/Unit/Handler/TarHandlerTest.php
+++ b/tests/Unit/Handler/TarHandlerTest.php
@@ -1,9 +1,8 @@
 <?php
 
-namespace LastCall\DownloadsPlugin\Tests\Unit;
+namespace LastCall\DownloadsPlugin\Tests\Unit\Handler;
 
 use LastCall\DownloadsPlugin\Handler\TarHandler;
-use LastCall\DownloadsPlugin\Tests\Unit\Handler\ArchiveHandlerTestCase;
 
 class TarHandlerTest extends ArchiveHandlerTestCase
 {

--- a/tests/Unit/Handler/XzHandlerTest.php
+++ b/tests/Unit/Handler/XzHandlerTest.php
@@ -1,9 +1,8 @@
 <?php
 
-namespace LastCall\DownloadsPlugin\Tests\Unit;
+namespace LastCall\DownloadsPlugin\Tests\Unit\Handler;
 
 use LastCall\DownloadsPlugin\Handler\XzHandler;
-use LastCall\DownloadsPlugin\Tests\Unit\Handler\ArchiveHandlerTestCase;
 
 class XzHandlerTest extends ArchiveHandlerTestCase
 {

--- a/tests/Unit/Handler/ZipHandlerTest.php
+++ b/tests/Unit/Handler/ZipHandlerTest.php
@@ -1,9 +1,8 @@
 <?php
 
-namespace LastCall\DownloadsPlugin\Tests\Unit;
+namespace LastCall\DownloadsPlugin\Tests\Unit\Handler;
 
 use LastCall\DownloadsPlugin\Handler\ZipHandler;
-use LastCall\DownloadsPlugin\Tests\Unit\Handler\ArchiveHandlerTestCase;
 
 class ZipHandlerTest extends ArchiveHandlerTestCase
 {

--- a/tests/Unit/SubpackageTest.php
+++ b/tests/Unit/SubpackageTest.php
@@ -3,6 +3,7 @@
 namespace LastCall\DownloadsPlugin\Tests\Unit;
 
 use Composer\Package\PackageInterface;
+use LastCall\DownloadsPlugin\Model\Hash;
 use LastCall\DownloadsPlugin\Model\Version;
 use LastCall\DownloadsPlugin\Subpackage;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -33,7 +34,18 @@ class SubpackageTest extends TestCase
         $this->parent = $this->createMock(PackageInterface::class);
     }
 
-    public function testInstance(): void
+    public function hashDataProvider(): array
+    {
+        return [
+            [null],
+            [new Hash('name', 'value')],
+        ];
+    }
+
+    /**
+     * @dataProvider hashDataProvider
+     */
+    public function testInstance(?Hash $hash): void
     {
         $this->parent->expects($this->once())->method('getName')->willReturn($this->parentName);
         $subpackage = new Subpackage(
@@ -45,7 +57,8 @@ class SubpackageTest extends TestCase
             $this->ignore,
             $this->url,
             $this->path,
-            new Version($this->version, $this->prettyVersion)
+            new Version($this->version, $this->prettyVersion),
+            $hash
         );
         $this->assertSame(sprintf('%s:%s', $this->parentName, $this->subpackageName), $subpackage->getName());
         $this->assertSame($this->version, $subpackage->getVersion());
@@ -60,5 +73,6 @@ class SubpackageTest extends TestCase
         $this->assertSame($this->ignore, $subpackage->getIgnore());
         $this->assertSame($this->parentPath, $subpackage->getParentPath());
         $this->assertSame($this->parentPath.\DIRECTORY_SEPARATOR.$this->path, $subpackage->getTargetPath());
+        $this->assertSame($hash, $subpackage->getHash());
     }
 }


### PR DESCRIPTION
* Since this feature related to security, when hash values are not match:
  * Downloaded file will be **deleted**
  * Composer will throw exception and **stop working**
* If syntax is invalid, composer write the error to the output and will **continue working**.
  * File will not be downloaded
  * Do we need to throw exception and stop working instead?