### PR TITLE
refactor: Rename and merge event handlers

### DIFF
--- a/src/Exception/OperationNotSupportedException.php
+++ b/src/Exception/OperationNotSupportedException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Exception;
+
+class OperationNotSupportedException extends BaseException
+{
+}


### PR DESCRIPTION
* Merge `installDownloads` + `updateDownloads` and rename to `handlePackageEvent`
* Rename `installDownloadsRoot` to `handleScriptEvent`