### PR TITLE
refactor(2.0): Use new code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "composer-plugin-api": "^2.0",
+        "composer-plugin-api": "^2.1",
         "php": "^8.1",
         "leongrdic/smplang": "^1.0.2",
         "symfony/filesystem": "^5.4 || ^6.4 || ^7.0",
@@ -42,6 +42,6 @@
         }
     },
     "extra": {
-        "class": "LastCall\\DownloadsPlugin\\Plugin"
+        "class": "LastCall\\DownloadsPlugin\\Composer\\Plugin\\ExtraDownloadsPlugin"
     }
 }

--- a/tests/Integration/Invalid/InvalidExecutableTest.php
+++ b/tests/Integration/Invalid/InvalidExecutableTest.php
@@ -24,6 +24,6 @@ class InvalidExecutableTest extends InstallInvalidExtraDownloadsTest
 
     protected static function getErrorMessage(): string
     {
-        return 'Skipped download extra files for package test/project: Attribute "executable" of extra file "invalid-executable" defined in package "test/project" are not valid paths.';
+        return 'Skipped download extra files for package test/project: Attribute "executable[*]" of extra file "invalid-executable" defined in package "test/project" must be relative path.';
     }
 }


### PR DESCRIPTION
* Refactoring code is done. This PR switch to new code
* Old code will be deleted in the next PR
* There is only one change to the integration test when switching to new code.
* Composer's api need to be updated to `^2.1`, as mentioned in https://github.com/pact-foundation/composer-downloads-plugin/pull/19#discussion_r1554526163