### PR TITLE
refactor(2.0): Add type enums

### DIFF
--- a/src/Enum/PackageType.php
+++ b/src/Enum/PackageType.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Enum;
+
+enum PackageType: string
+{
+    private const TYPE_PREFIX = 'extra-download:';
+
+    case ARCHIVE = self::TYPE_PREFIX.'archive';
+    case GZIP = self::TYPE_PREFIX.'gzip';
+    case FILE = self::TYPE_PREFIX.'file';
+}

--- a/src/Enum/Type.php
+++ b/src/Enum/Type.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Enum;
+
+enum Type: string
+{
+    case ZIP = 'zip';
+    case RAR = 'rar';
+    case TAR = 'tar';
+    case XZ = 'xz';
+    case FILE = 'file';
+    case PHAR = 'phar';
+    case GZIP = 'gzip';
+
+    public function isArchive(): bool
+    {
+        return match ($this) {
+            self::ZIP => true,
+            self::RAR => true,
+            self::TAR => true,
+            self::XZ => true,
+            default => false,
+        };
+    }
+
+    public static function fromExtension(string $extension): self
+    {
+        return match ($extension) {
+            'zip' => self::ZIP,
+            'rar' => self::RAR,
+            'tgz', 'tar' => self::TAR,
+            'gz' => self::GZIP,
+            'phar' => self::PHAR,
+            default => self::FILE,
+        };
+    }
+
+    public function toDistType(): string
+    {
+        return self::PHAR === $this ? 'file' : $this->value;
+    }
+
+    public function toPackageType(): PackageType
+    {
+        if ($this->isArchive()) {
+            return PackageType::ARCHIVE;
+        }
+        if (self::GZIP === $this) {
+            return PackageType::GZIP;
+        }
+
+        return PackageType::FILE;
+    }
+}

--- a/tests/Unit/Enum/TypeTest.php
+++ b/tests/Unit/Enum/TypeTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Tests\Unit\Enum;
+
+use LastCall\DownloadsPlugin\Enum\Type;
+use PHPUnit\Framework\TestCase;
+
+class TypeTest extends TestCase
+{
+    public function getIsArchiveTests(): array
+    {
+        return [
+            [Type::ZIP, true],
+            [Type::RAR, true],
+            [Type::TAR, true],
+            [Type::XZ, true],
+            [Type::FILE, false],
+            [Type::PHAR, false],
+            [Type::GZIP, false],
+        ];
+    }
+
+    /**
+     * @dataProvider getIsArchiveTests
+     */
+    public function testIsArchive(Type $type, bool $isArchive): void
+    {
+        $this->assertSame($isArchive, $type->isArchive());
+    }
+
+    public function getFromExtensionTests(): array
+    {
+        return [
+            ['zip', Type::ZIP],
+            ['rar', Type::RAR],
+            ['tgz', Type::TAR],
+            ['tar', Type::TAR],
+            // ['tar.gz', Type::TAR], // Handle in TypeValidator::parseUrl()
+            // ['tar.bz2', Type::TAR], // Handle in TypeValidator::parseUrl()
+            // ['tar.xz', Type::XZ], // Handle in TypeValidator::parseUrl()
+            ['gz', Type::GZIP],
+            ['phar', Type::PHAR],
+            ['csv', Type::FILE],
+        ];
+    }
+
+    /**
+     * @dataProvider getFromExtensionTests
+     */
+    public function testFromExtension(string $extension, Type $type): void
+    {
+        $this->assertSame($type, Type::fromExtension($extension));
+    }
+
+    public function getToDistTypeTests(): array
+    {
+        return [
+            [Type::ZIP, 'zip'],
+            [Type::RAR, 'rar'],
+            [Type::TAR, 'tar'],
+            [Type::XZ, 'xz'],
+            [Type::FILE, 'file'],
+            [Type::PHAR, 'file'],
+            [Type::GZIP, 'gzip'],
+        ];
+    }
+
+    /**
+     * @dataProvider getToDistTypeTests
+     */
+    public function testToDistType(Type $type, string $distType): void
+    {
+        $this->assertSame($distType, $type->toDistType());
+    }
+
+    public function getToPackageTypeTests(): array
+    {
+        return [
+            [Type::ZIP, 'extra-download:archive'],
+            [Type::RAR, 'extra-download:archive'],
+            [Type::TAR, 'extra-download:archive'],
+            [Type::XZ, 'extra-download:archive'],
+            [Type::FILE, 'extra-download:file'],
+            [Type::PHAR, 'extra-download:file'],
+            [Type::GZIP, 'extra-download:gzip'],
+        ];
+    }
+
+    /**
+     * @dataProvider getToPackageTypeTests
+     */
+    public function testToPackageType(Type $type, string $packageType): void
+    {
+        $this->assertSame($packageType, $type->toPackageType()->value);
+    }
+}


### PR DESCRIPTION
First PR for 2.0 refactoring.

In this PR I add 2 enums.

I tried to add `TypeInterface` but then I reverted the code to `Type` enum. The reasons are:
- Composer only support these types. Adding new class extending `TypeInterface` doesn't automatically support that type.
- I think we need to add test another class `TypeManager` with a property called `$types` which hold list of types to check for supported types in `TypeValidator`. Adding new class extending `TypeInterface` is not enough, we need to update `TypeManager::$types`. So we are just moving the enum to another kind of enum.