### PR TITLE
refactor(2.0): Add composer's package

### DIFF
--- a/src/Composer/Package/ExtraDownload.php
+++ b/src/Composer/Package/ExtraDownload.php
@@ -2,9 +2,10 @@
 
 namespace LastCall\DownloadsPlugin\Composer\Package;
 
-use Composer\InstalledVersions;
 use Composer\Package\Package;
 use Composer\Package\PackageInterface;
+use LastCall\DownloadsPlugin\Composer\Package\InstallPath\InstallPath;
+use LastCall\DownloadsPlugin\Composer\Package\InstallPath\InstallPathInterface;
 use LastCall\DownloadsPlugin\Composer\Package\Tracking\FileTracking;
 use LastCall\DownloadsPlugin\Composer\Package\Tracking\TrackingInterface;
 use LastCall\DownloadsPlugin\Enum\Type;
@@ -15,9 +16,10 @@ class ExtraDownload extends Package implements ExtraDownloadInterface
     public const FAKE_VERSION = 'dev-master';
 
     protected TrackingInterface $tracking;
+    private InstallPathInterface $installPath;
 
     public function __construct(
-        private PackageInterface $parent,
+        PackageInterface $parent,
         string $id,
         ?string $version,
         private ?Hash $hash,
@@ -37,6 +39,7 @@ class ExtraDownload extends Package implements ExtraDownloadInterface
         $this->setDistUrl($url);
         $this->setTargetDir($path);
         $this->tracking = new FileTracking($this->getName(), $url, $path, $type, $executable);
+        $this->installPath = new InstallPath($parent);
     }
 
     public function getTrackingChecksum(): string
@@ -46,12 +49,12 @@ class ExtraDownload extends Package implements ExtraDownloadInterface
 
     public function getInstallPath(): string
     {
-        return $this->getParentPath().\DIRECTORY_SEPARATOR.$this->getTargetDir();
+        return $this->installPath->convertToAbsolute($this->getTargetDir());
     }
 
     public function getExecutablePaths(): array
     {
-        return array_map(fn (string $bin) => $this->getParentPath().\DIRECTORY_SEPARATOR.$bin, $this->executable);
+        return array_map(fn (string $bin) => $this->installPath->convertToAbsolute($bin), $this->executable);
     }
 
     public function verifyFile(string $path): bool
@@ -61,10 +64,5 @@ class ExtraDownload extends Package implements ExtraDownloadInterface
         }
 
         return $this->hash->verifyFile($path);
-    }
-
-    private function getParentPath(): string
-    {
-        return InstalledVersions::getInstallPath($this->parent->getName());
     }
 }

--- a/src/Composer/Package/ExtraDownload.php
+++ b/src/Composer/Package/ExtraDownload.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Composer\Package;
+
+use Composer\InstalledVersions;
+use Composer\Package\Package;
+use Composer\Package\PackageInterface;
+use LastCall\DownloadsPlugin\Enum\Type;
+use LastCall\DownloadsPlugin\Model\Hash;
+
+class ExtraDownload extends Package implements ExtraDownloadInterface
+{
+    public const FAKE_VERSION = 'dev-master';
+
+    public function __construct(
+        private PackageInterface $parent,
+        string $id,
+        ?string $version,
+        private ?Hash $hash,
+        private Type $extraDownloadType,
+        private array $executable,
+    ) {
+        parent::__construct(
+            sprintf('%s:%s', $parent->getName(), $id),
+            self::FAKE_VERSION,
+            $version ?? self::FAKE_VERSION,
+        );
+        $this->setInstallationSource('dist');
+        $this->setDistType($extraDownloadType->toDistType());
+        $this->setType($extraDownloadType->toPackageType()->value);
+    }
+
+    public function getTrackingChecksum(): string
+    {
+        return hash('sha256', serialize($this->getTrackingChecksumData()));
+    }
+
+    public function getInstallPath(): string
+    {
+        return $this->getParentPath().\DIRECTORY_SEPARATOR.$this->getTargetDir();
+    }
+
+    public function getExecutablePaths(): array
+    {
+        return array_map(fn (string $bin) => $this->getParentPath().\DIRECTORY_SEPARATOR.$bin, $this->executable);
+    }
+
+    public function verifyFile(string $path): bool
+    {
+        if (null === $this->hash) {
+            return true;
+        }
+
+        return $this->hash->verifyFile($path);
+    }
+
+    protected function getTrackingChecksumData(): array
+    {
+        return [
+            'id' => $this->getName(),
+            'url' => $this->getDistUrl(),
+            'path' => $this->getTargetDir(),
+            'type' => $this->extraDownloadType,
+            'executable' => $this->executable,
+        ];
+    }
+
+    private function getParentPath(): string
+    {
+        return InstalledVersions::getInstallPath($this->parent->getName());
+    }
+}

--- a/src/Composer/Package/ExtraDownloadInterface.php
+++ b/src/Composer/Package/ExtraDownloadInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Composer\Package;
+
+use Composer\Package\PackageInterface;
+
+interface ExtraDownloadInterface extends PackageInterface
+{
+    public function getTrackingChecksum(): string;
+
+    public function getInstallPath(): string;
+
+    public function getExecutablePaths(): array;
+
+    public function verifyFile(string $path): bool;
+}

--- a/src/Composer/Package/InstallPath/InstallPath.php
+++ b/src/Composer/Package/InstallPath/InstallPath.php
@@ -13,10 +13,10 @@ class InstallPath implements InstallPathInterface
 
     public function convertToAbsolute(string $relative): string
     {
-        return $this->getParentPath().\DIRECTORY_SEPARATOR.$relative;
+        return $this->getPackageInstallPath().\DIRECTORY_SEPARATOR.$relative;
     }
 
-    private function getParentPath(): string
+    private function getPackageInstallPath(): string
     {
         return InstalledVersions::getInstallPath($this->package->getName());
     }

--- a/src/Composer/Package/InstallPath/InstallPath.php
+++ b/src/Composer/Package/InstallPath/InstallPath.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Composer\Package\InstallPath;
+
+use Composer\InstalledVersions;
+use Composer\Package\PackageInterface;
+
+class InstallPath implements InstallPathInterface
+{
+    public function __construct(private PackageInterface $package)
+    {
+    }
+
+    public function convertToAbsolute(string $relative): string
+    {
+        return $this->getParentPath().\DIRECTORY_SEPARATOR.$relative;
+    }
+
+    private function getParentPath(): string
+    {
+        return InstalledVersions::getInstallPath($this->package->getName());
+    }
+}

--- a/src/Composer/Package/InstallPath/InstallPathInterface.php
+++ b/src/Composer/Package/InstallPath/InstallPathInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Composer\Package\InstallPath;
+
+interface InstallPathInterface
+{
+    public function convertToAbsolute(string $relative): string;
+}

--- a/src/Composer/Package/Tracking/ArchiveTracking.php
+++ b/src/Composer/Package/Tracking/ArchiveTracking.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Composer\Package\Tracking;
+
+use LastCall\DownloadsPlugin\Enum\Type;
+
+class ArchiveTracking extends FileTracking implements TrackingInterface
+{
+    public function __construct(
+        string $id,
+        string $url,
+        string $path,
+        Type $type,
+        array $executable,
+        private array $ignore,
+    ) {
+        parent::__construct($id, $url, $path, $type, $executable);
+    }
+
+    protected function getChecksumData(): array
+    {
+        return parent::getChecksumData() + [
+            'ignore' => $this->ignore,
+        ];
+    }
+}

--- a/src/Composer/Package/Tracking/FileTracking.php
+++ b/src/Composer/Package/Tracking/FileTracking.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Composer\Package\Tracking;
+
+use LastCall\DownloadsPlugin\Enum\Type;
+
+class FileTracking implements TrackingInterface
+{
+    public function __construct(
+        private string $id,
+        private string $url,
+        private string $path,
+        private Type $type,
+        private array $executable,
+    ) {
+    }
+
+    public function getChecksum(): string
+    {
+        return hash('sha256', serialize($this->getChecksumData()));
+    }
+
+    protected function getChecksumData(): array
+    {
+        return [
+            'id' => $this->id,
+            'url' => $this->url,
+            'path' => $this->path,
+            'type' => $this->type,
+            'executable' => $this->executable,
+        ];
+    }
+}

--- a/src/Composer/Package/Tracking/TrackingInterface.php
+++ b/src/Composer/Package/Tracking/TrackingInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Composer\Package\Tracking;
+
+interface TrackingInterface
+{
+    public function getChecksum(): string;
+}

--- a/tests/Unit/Composer/Package/ExtraDownloadTest.php
+++ b/tests/Unit/Composer/Package/ExtraDownloadTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Tests\Unit\Composer\Package;
+
+use Composer\Package\Package;
+use Composer\Package\PackageInterface;
+use LastCall\DownloadsPlugin\Composer\Package\ExtraDownload;
+use LastCall\DownloadsPlugin\Enum\Type;
+use LastCall\DownloadsPlugin\Model\Hash;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ExtraDownloadTest extends TestCase
+{
+    private ExtraDownload $extraDownload;
+    private PackageInterface $parent;
+    private Hash|MockObject $hash;
+    private string $parentName = 'vendor/package-name';
+    private string $name = 'normal-file';
+    private array $executable = [
+        'file1',
+        'path/to/file2',
+    ];
+    private string $version = '1.2.3.0';
+    private string $path = 'path/to/dir';
+
+    protected function setUp(): void
+    {
+        $this->parent = new Package($this->parentName, '1.2.3', 'v1.2.3');
+        $this->hash = $this->createMock(Hash::class);
+        $this->createExtraDownload($this->parent, $this->hash);
+    }
+
+    public function testConstruct(): void
+    {
+        $this->assertSame("{$this->parentName}:{$this->name}", $this->extraDownload->getName());
+        $this->assertSame('dev-master', $this->extraDownload->getVersion());
+        $this->assertSame($this->version, $this->extraDownload->getPrettyVersion());
+        $this->assertSame('dist', $this->extraDownload->getInstallationSource());
+        $this->assertSame('zip', $this->extraDownload->getDistType());
+        $this->assertSame('extra-download:archive', $this->extraDownload->getType());
+    }
+
+    public function testGetTrackingChecksum(): void
+    {
+        $this->assertSame('81a2647565ec9e478ad0c0fc72fd91500b664d12f484d47bdc8439d21f2fe432', $this->extraDownload->getTrackingChecksum());
+    }
+
+    public function testGetInstallPathWhenParentPackageIsNotInstalled(): void
+    {
+        $this->expectException(\OutOfBoundsException::class);
+        $this->expectExceptionMessage('Package "'.$this->parentName.'" is not installed');
+        $this->extraDownload->getInstallPath();
+    }
+
+    public function testGetInstallPathWhenParentPackageIsInstalled(): void
+    {
+        $parentName = 'leongrdic/smplang';
+        $parent = new Package($parentName, 'any version', 'any pretty version');
+        $this->createExtraDownload($parent, $this->hash);
+        $this->extraDownload->setTargetDir($this->path);
+        $this->assertSame(
+            realpath(__DIR__.'/../../../../vendor/composer/').'/../'.$parentName.'/'.$this->path,
+            $this->extraDownload->getInstallPath()
+        );
+    }
+
+    public function testGetExecutablePathsWhenParentPackageIsNotInstalled(): void
+    {
+        $this->expectException(\OutOfBoundsException::class);
+        $this->expectExceptionMessage('Package "'.$this->parentName.'" is not installed');
+        $this->extraDownload->getExecutablePaths();
+    }
+
+    public function testGetExecutablePathsWhenParentPackageIsInstalled(): void
+    {
+        $parentName = 'leongrdic/smplang';
+        $parent = new Package($parentName, 'any version', 'any pretty version');
+        $this->createExtraDownload($parent, $this->hash);
+        $this->extraDownload->setTargetDir($this->path);
+        $this->assertSame([
+            realpath(__DIR__.'/../../../../vendor/composer/').'/../'.$parentName.'/file1',
+            realpath(__DIR__.'/../../../../vendor/composer/').'/../'.$parentName.'/path/to/file2',
+        ], $this->extraDownload->getExecutablePaths());
+    }
+
+    public function testVerifyFileWithoutHash(): void
+    {
+        $this->createExtraDownload($this->parent, null);
+        $this->assertTrue($this->extraDownload->verifyFile('/any/file'));
+    }
+
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testVerifyFileWithHash(bool $isValid): void
+    {
+        $path = '/path/to/file';
+        $this->hash
+            ->expects($this->once())
+            ->method('verifyFile')
+            ->with($path)
+            ->willReturn($isValid);
+        $this->assertSame($isValid, $this->extraDownload->verifyFile($path));
+    }
+
+    private function createExtraDownload(PackageInterface $parent, ?Hash $hash): void
+    {
+        $this->extraDownload = new ExtraDownload(
+            $parent,
+            $this->name,
+            $this->version,
+            $hash,
+            Type::ZIP,
+            $this->executable,
+        );
+    }
+}

--- a/tests/Unit/Composer/Package/ExtraDownloadTest.php
+++ b/tests/Unit/Composer/Package/ExtraDownloadTest.php
@@ -22,6 +22,7 @@ class ExtraDownloadTest extends TestCase
         'path/to/file2',
     ];
     private string $version = '1.2.3.0';
+    private string $url = 'http://example.com/file.zip';
     private string $path = 'path/to/dir';
 
     protected function setUp(): void
@@ -43,7 +44,7 @@ class ExtraDownloadTest extends TestCase
 
     public function testGetTrackingChecksum(): void
     {
-        $this->assertSame('81a2647565ec9e478ad0c0fc72fd91500b664d12f484d47bdc8439d21f2fe432', $this->extraDownload->getTrackingChecksum());
+        $this->assertSame('81d3735ad458e2f10551fd022d11aa344774a3b48076b3dbfb633fa96c3572a6', $this->extraDownload->getTrackingChecksum());
     }
 
     public function testGetInstallPathWhenParentPackageIsNotInstalled(): void
@@ -58,7 +59,6 @@ class ExtraDownloadTest extends TestCase
         $parentName = 'leongrdic/smplang';
         $parent = new Package($parentName, 'any version', 'any pretty version');
         $this->createExtraDownload($parent, $this->hash);
-        $this->extraDownload->setTargetDir($this->path);
         $this->assertSame(
             realpath(__DIR__.'/../../../../vendor/composer/').'/../'.$parentName.'/'.$this->path,
             $this->extraDownload->getInstallPath()
@@ -77,7 +77,6 @@ class ExtraDownloadTest extends TestCase
         $parentName = 'leongrdic/smplang';
         $parent = new Package($parentName, 'any version', 'any pretty version');
         $this->createExtraDownload($parent, $this->hash);
-        $this->extraDownload->setTargetDir($this->path);
         $this->assertSame([
             realpath(__DIR__.'/../../../../vendor/composer/').'/../'.$parentName.'/file1',
             realpath(__DIR__.'/../../../../vendor/composer/').'/../'.$parentName.'/path/to/file2',
@@ -114,6 +113,8 @@ class ExtraDownloadTest extends TestCase
             $hash,
             Type::ZIP,
             $this->executable,
+            $this->url,
+            $this->path
         );
     }
 }

--- a/tests/Unit/Composer/Package/InstallPath/InstallPathTest.php
+++ b/tests/Unit/Composer/Package/InstallPath/InstallPathTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Tests\Unit\Composer\Package\InstallPath;
+
+use Composer\Package\PackageInterface;
+use LastCall\DownloadsPlugin\Composer\Package\InstallPath\InstallPath;
+use LastCall\DownloadsPlugin\Composer\Package\InstallPath\InstallPathInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class InstallPathTest extends TestCase
+{
+    private InstallPathInterface $installPath;
+    private PackageInterface|MockObject $package;
+    private string $relative = 'path/to/file';
+
+    protected function setUp(): void
+    {
+        $this->package = $this->createMock(PackageInterface::class);
+        $this->installPath = new InstallPath($this->package);
+    }
+
+    public function testConvertToAbsoluteWhenPackageIsNotInstalled(): void
+    {
+        $name = 'vendor/package-name';
+        $this->package
+            ->expects($this->once())
+            ->method('getName')
+            ->willReturn($name);
+        $this->expectException(\OutOfBoundsException::class);
+        $this->expectExceptionMessage('Package "'.$name.'" is not installed');
+        $this->installPath->convertToAbsolute($this->relative);
+    }
+
+    public function testConvertToAbsoluteWhenPackageIsInstalled(): void
+    {
+        $name = 'leongrdic/smplang';
+        $this->package
+            ->expects($this->once())
+            ->method('getName')
+            ->willReturn($name);
+        $this->assertSame(
+            realpath(__DIR__.'/../../../../../vendor/composer/').'/../'.$name.'/'.$this->relative,
+            $this->installPath->convertToAbsolute($this->relative)
+        );
+    }
+}

--- a/tests/Unit/Composer/Package/Tracking/ArchiveTrackingTest.php
+++ b/tests/Unit/Composer/Package/Tracking/ArchiveTrackingTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Tests\Unit\Composer\Package\Tracking;
+
+use LastCall\DownloadsPlugin\Composer\Package\Tracking\ArchiveTracking;
+
+class ArchiveTrackingTest extends FileTrackingTest
+{
+    private array $ignore = [
+        'dir/*',
+        '!dir/file1',
+    ];
+
+    protected function setUp(): void
+    {
+        $this->tracking = new ArchiveTracking($this->name, $this->url, $this->path, $this->type, $this->executable, $this->ignore);
+    }
+
+    public function testGetChecksum(): void
+    {
+        $this->assertSame('f876342d677c28a6f3010c62ef052d9ec305c1d5e83ed0f4095dca2d2a79fda5', $this->tracking->getChecksum());
+    }
+}

--- a/tests/Unit/Composer/Package/Tracking/FileTrackingTest.php
+++ b/tests/Unit/Composer/Package/Tracking/FileTrackingTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Tests\Unit\Composer\Package\Tracking;
+
+use LastCall\DownloadsPlugin\Composer\Package\Tracking\FileTracking;
+use LastCall\DownloadsPlugin\Composer\Package\Tracking\TrackingInterface;
+use LastCall\DownloadsPlugin\Enum\Type;
+use PHPUnit\Framework\TestCase;
+
+class FileTrackingTest extends TestCase
+{
+    protected TrackingInterface $tracking;
+    protected string $name = 'normal-file';
+    protected string $url = 'http://example.com/file.zip';
+    protected string $path = 'path/to/dir';
+    protected Type $type = Type::ZIP;
+    protected array $executable = [
+        'file1',
+        'path/to/file2',
+    ];
+
+    protected function setUp(): void
+    {
+        $this->tracking = new FileTracking($this->name, $this->url, $this->path, $this->type, $this->executable);
+    }
+
+    public function testGetChecksum(): void
+    {
+        $this->assertSame('d2ffb87c3fc709cc36cc08791b1b1dfb6292d0d403fc091a9f5584768c0f35fa', $this->tracking->getChecksum());
+    }
+}


### PR DESCRIPTION
This `ExtraDownload` class is similar to `Subpackage` class, but:
- ~~Removed the bloated constructor~~
- ~~Added new property `downloadedPath`~~
- Removed constructor parameters
  -  `parentPath`
  -  `ignore`
- Removed getters/setters
- Add methods
  - `getTrackingChecksum`
  - `getInstallPath`
  - `getExecutablePaths`
  -  `verifyFile`