### PR TITLE
refactor(2.0): Add PathValidator

### DIFF
--- a/src/Attribute/Validator/AbstractValidator.php
+++ b/src/Attribute/Validator/AbstractValidator.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Attribute\Validator;
+
+use Composer\Package\PackageInterface;
+use LastCall\DownloadsPlugin\Exception\UnexpectedValueException;
+
+abstract class AbstractValidator implements ValidatorInterface
+{
+    public function __construct(
+        protected string $id,
+        protected PackageInterface $parent
+    ) {
+    }
+
+    protected function throwException(string $attribute, string $reason): void
+    {
+        throw new UnexpectedValueException(sprintf('Attribute "%s" of extra file "%s" defined in package "%s" %s.', $attribute, $this->id, $this->parent->getName(), $reason));
+    }
+}

--- a/src/Attribute/Validator/PathValidator.php
+++ b/src/Attribute/Validator/PathValidator.php
@@ -33,7 +33,7 @@ class PathValidator extends AbstractValidator
             $this->throwException($this->getAttribute(), 'must be relative path');
         }
 
-        if (preg_match("[\.\.|\0]", $path)) {
+        if (str_contains($path, '..') || str_contains($path, "\0")) {
             $this->throwException($this->getAttribute(), "must be inside relative to parent package's path");
         }
 

--- a/src/Attribute/Validator/PathValidator.php
+++ b/src/Attribute/Validator/PathValidator.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Attribute\Validator;
+
+use Composer\Package\PackageInterface;
+use LastCall\DownloadsPlugin\Attribute\AttributeManagerInterface;
+use LastCall\DownloadsPlugin\Enum\Attribute;
+use Symfony\Component\Filesystem\Path;
+
+class PathValidator extends AbstractValidator
+{
+    public function __construct(
+        string $id,
+        PackageInterface $parent,
+        private AttributeManagerInterface $attributeManager,
+        private string $attribute = 'path',
+    ) {
+        parent::__construct($id, $parent);
+    }
+
+    public function validate(mixed $value): string
+    {
+        if (null === $value) {
+            $this->throwException($this->getAttribute(), 'is required');
+        }
+
+        if (!\is_string($value)) {
+            $this->throwException($this->getAttribute(), sprintf('must be string, "%s" given', get_debug_type($value)));
+        }
+
+        $path = strtr($value, $this->attributeManager->get(Attribute::VARIABLES));
+        if (Path::isAbsolute($path)) {
+            $this->throwException($this->getAttribute(), 'must be relative path');
+        }
+
+        if (preg_match("[\.\.|\0]", $path)) {
+            $this->throwException($this->getAttribute(), "must be inside relative to parent package's path");
+        }
+
+        return $path;
+    }
+
+    public function getAttribute(): string
+    {
+        return $this->attribute;
+    }
+}

--- a/tests/Unit/Attribute/Validator/AbstractValidatorTestCase.php
+++ b/tests/Unit/Attribute/Validator/AbstractValidatorTestCase.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Tests\Unit\Attribute\Validator;
+
+use Composer\Package\PackageInterface;
+use LastCall\DownloadsPlugin\Attribute\AttributeManagerInterface;
+use LastCall\DownloadsPlugin\Attribute\Validator\ValidatorInterface;
+use LastCall\DownloadsPlugin\Exception\UnexpectedValueException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractValidatorTestCase extends TestCase
+{
+    protected PackageInterface|MockObject $parent;
+    protected AttributeManagerInterface|MockObject $attributeManager;
+    protected ValidatorInterface $validator;
+    protected string $id = 'file-name';
+    protected string $parentName = 'vendor/parent-package';
+    protected string $parentPath = '/path/to/vendor/parent-package';
+
+    protected function setUp(): void
+    {
+        $this->parent = $this->createMock(PackageInterface::class);
+        $this->attributeManager = $this->createMock(AttributeManagerInterface::class);
+        $this->validator = $this->createValidator();
+    }
+
+    protected function expectUnexpectedValueException(string $attribute, string $reason): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage(sprintf('Attribute "%s" of extra file "%s" defined in package "%s" %s.', $attribute, $this->id, $this->parentName, $reason));
+    }
+
+    abstract protected function createValidator(): ValidatorInterface;
+}

--- a/tests/Unit/Attribute/Validator/PathValidatorTest.php
+++ b/tests/Unit/Attribute/Validator/PathValidatorTest.php
@@ -44,8 +44,8 @@ class PathValidatorTest extends AbstractValidatorTestCase
     public function getAbsolutePathTests(): array
     {
         return [
-            ['C:\Programs\PHP\php.ini'],
-            ['/var/www/project/uploads'],
+            ['D:\path\to\text.txt'],
+            ['/path/to/note.md'],
         ];
     }
 
@@ -67,7 +67,7 @@ class PathValidatorTest extends AbstractValidatorTestCase
             ['..../other/place', []],
             ["path/to/file\0", []],
             ["path/to/file\0/../../../other/place", []],
-            ['path/to/{$file}', ['{$file}' => '../../../etc/passwd']],
+            ['path/to/{$file}', ['{$file}' => '../../../path/to/another/file']],
         ];
     }
 

--- a/tests/Unit/Attribute/Validator/PathValidatorTest.php
+++ b/tests/Unit/Attribute/Validator/PathValidatorTest.php
@@ -67,6 +67,7 @@ class PathValidatorTest extends AbstractValidatorTestCase
             ['..../other/place', []],
             ["path/to/file\0", []],
             ["path/to/file\0/../../../other/place", []],
+            ['path/to/file/../../../other/place/../..', []],
             ['path/to/{$file}', ['{$file}' => '../../../path/to/another/file']],
         ];
     }

--- a/tests/Unit/Attribute/Validator/PathValidatorTest.php
+++ b/tests/Unit/Attribute/Validator/PathValidatorTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Tests\Unit\Attribute\Validator;
+
+use LastCall\DownloadsPlugin\Attribute\Validator\PathValidator;
+use LastCall\DownloadsPlugin\Attribute\Validator\ValidatorInterface;
+use LastCall\DownloadsPlugin\Enum\Attribute;
+
+class PathValidatorTest extends AbstractValidatorTestCase
+{
+    private string $attribute = 'path';
+
+    public function testNull(): void
+    {
+        $this->parent->expects($this->once())->method('getName')->willReturn($this->parentName);
+        $this->attributeManager->expects($this->never())->method('get');
+        $this->expectUnexpectedValueException($this->attribute, 'is required');
+        $this->validator->validate(null);
+    }
+
+    public function getInvalidPathTests(): array
+    {
+        return [
+            [true, 'bool'],
+            [false, 'bool'],
+            [123, 'int'],
+            [12.3, 'float'],
+            [['key' => 'value'], 'array'],
+            [(object) ['key' => 'value'], 'stdClass'],
+        ];
+    }
+
+    /**
+     * @dataProvider getInvalidPathTests
+     */
+    public function testInvalidPath(mixed $invalidPath, string $type): void
+    {
+        $this->parent->expects($this->once())->method('getName')->willReturn($this->parentName);
+        $this->attributeManager->expects($this->never())->method('get');
+        $this->expectUnexpectedValueException($this->attribute, sprintf('must be string, "%s" given', $type));
+        $this->validator->validate($invalidPath);
+    }
+
+    public function getAbsolutePathTests(): array
+    {
+        return [
+            ['C:\Programs\PHP\php.ini'],
+            ['/var/www/project/uploads'],
+        ];
+    }
+
+    /**
+     * @dataProvider getAbsolutePathTests
+     */
+    public function testAbsolutePathFile(string $absolutePath): void
+    {
+        $this->attributeManager->expects($this->once())->method('get')->with(Attribute::VARIABLES)->willReturn([]);
+        $this->parent->expects($this->once())->method('getName')->willReturn($this->parentName);
+        $this->expectUnexpectedValueException($this->attribute, 'must be relative path');
+        $this->validator->validate($absolutePath);
+    }
+
+    public function getOutsidePathTests(): array
+    {
+        return [
+            ['../../other/place', []],
+            ['..../other/place', []],
+            ["path/to/file\0", []],
+            ["path/to/file\0/../../../other/place", []],
+            ['path/to/{$file}', ['{$file}' => '../../../etc/passwd']],
+        ];
+    }
+
+    /**
+     * @dataProvider getOutsidePathTests
+     */
+    public function testOutsidePath(string $outsidePath, array $variables): void
+    {
+        $this->attributeManager->expects($this->once())->method('get')->with(Attribute::VARIABLES)->willReturn($variables);
+        $this->parent->expects($this->once())->method('getName')->willReturn($this->parentName);
+        $this->expectUnexpectedValueException($this->attribute, "must be inside relative to parent package's path");
+        $this->validator->validate($outsidePath);
+    }
+
+    public function getFilterPathTests(): array
+    {
+        return [
+            ['path/to/file', [], 'path/to/file'],
+            ['path/to/file/{$version}', ['{$version}' => '1.2.3'], 'path/to/file/1.2.3'],
+        ];
+    }
+
+    /**
+     * @dataProvider getFilterPathTests
+     */
+    public function testFilterPath(string $path, array $variables, string $expectedPath): void
+    {
+        $this->attributeManager->expects($this->once())->method('get')->with(Attribute::VARIABLES)->willReturn($variables);
+        $this->parent->expects($this->never())->method('getName');
+        $this->assertSame($expectedPath, $this->validator->validate($path));
+    }
+
+    protected function createValidator(): ValidatorInterface
+    {
+        return new PathValidator($this->id, $this->parent, $this->attributeManager, $this->attribute);
+    }
+}


### PR DESCRIPTION
Path must be:

* Required
* String
* Relative (to parent package's install path)
* Doesn't contains invalid string like `..` or `\0` (null byte) - to prevent Directory Traversal

I'm new to security stuff. Any advices on this would be nice.