### PR TITLE
refactor(2.0): Remove gzip package type

### DIFF
--- a/src/Enum/PackageType.php
+++ b/src/Enum/PackageType.php
@@ -7,6 +7,5 @@ enum PackageType: string
     private const TYPE_PREFIX = 'extra-download:';
 
     case ARCHIVE = self::TYPE_PREFIX.'archive';
-    case GZIP = self::TYPE_PREFIX.'gzip';
     case FILE = self::TYPE_PREFIX.'file';
 }

--- a/src/Enum/Type.php
+++ b/src/Enum/Type.php
@@ -45,9 +45,6 @@ enum Type: string
         if ($this->isArchive()) {
             return PackageType::ARCHIVE;
         }
-        if (self::GZIP === $this) {
-            return PackageType::GZIP;
-        }
 
         return PackageType::FILE;
     }

--- a/tests/Unit/Enum/TypeTest.php
+++ b/tests/Unit/Enum/TypeTest.php
@@ -82,7 +82,7 @@ class TypeTest extends TestCase
             [Type::XZ, 'extra-download:archive'],
             [Type::FILE, 'extra-download:file'],
             [Type::PHAR, 'extra-download:file'],
-            [Type::GZIP, 'extra-download:gzip'],
+            [Type::GZIP, 'extra-download:file'],
         ];
     }
 


### PR DESCRIPTION
I have a new approach (no PR for it yet) that can merge `GzipInstaller` into `FileInstaller`. That's why `gzip` package type is no longer needed.