### PR TITLE
refactor(2.0): Add ExtraDownload factories

### DIFF
--- a/src/Factory/ExtraArchiveFactory.php
+++ b/src/Factory/ExtraArchiveFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Factory;
+
+use Composer\Package\PackageInterface;
+use LastCall\DownloadsPlugin\Composer\Package\ExtraArchive;
+use LastCall\DownloadsPlugin\Enum\Attribute;
+
+class ExtraArchiveFactory extends ExtraDownloadFactory
+{
+    public function create(string $id, PackageInterface $parent): PackageInterface
+    {
+        return new ExtraArchive(
+            $parent,
+            $id,
+            $this->attributeManager->get(Attribute::VERSION),
+            $this->attributeManager->get(Attribute::HASH),
+            $this->attributeManager->get(Attribute::TYPE),
+            $this->attributeManager->get(Attribute::EXECUTABLE),
+            $this->attributeManager->get(Attribute::URL),
+            $this->attributeManager->get(Attribute::PATH),
+            $this->attributeManager->get(Attribute::IGNORE),
+        );
+    }
+}

--- a/src/Factory/ExtraDownloadFactory.php
+++ b/src/Factory/ExtraDownloadFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Factory;
+
+use Composer\Package\PackageInterface;
+use LastCall\DownloadsPlugin\Attribute\AttributeManagerInterface;
+use LastCall\DownloadsPlugin\Composer\Package\ExtraDownload;
+use LastCall\DownloadsPlugin\Enum\Attribute;
+
+class ExtraDownloadFactory implements ExtraDownloadFactoryInterface
+{
+    public function __construct(
+        protected AttributeManagerInterface $attributeManager,
+    ) {
+    }
+
+    public function create(string $id, PackageInterface $parent): PackageInterface
+    {
+        return new ExtraDownload(
+            $parent,
+            $id,
+            $this->attributeManager->get(Attribute::VERSION),
+            $this->attributeManager->get(Attribute::HASH),
+            $this->attributeManager->get(Attribute::TYPE),
+            $this->attributeManager->get(Attribute::EXECUTABLE),
+            $this->attributeManager->get(Attribute::URL),
+            $this->attributeManager->get(Attribute::PATH),
+        );
+    }
+}

--- a/src/Factory/ExtraDownloadFactoryInterface.php
+++ b/src/Factory/ExtraDownloadFactoryInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Factory;
+
+use Composer\Package\PackageInterface;
+
+interface ExtraDownloadFactoryInterface
+{
+    public function create(string $id, PackageInterface $parent): PackageInterface;
+}

--- a/tests/Unit/Factory/ExtraArchiveFactoryTest.php
+++ b/tests/Unit/Factory/ExtraArchiveFactoryTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Tests\Unit\Factory;
+
+use LastCall\DownloadsPlugin\Composer\Package\ExtraArchive;
+use LastCall\DownloadsPlugin\Enum\Attribute;
+use LastCall\DownloadsPlugin\Factory\ExtraArchiveFactory;
+use LastCall\DownloadsPlugin\Factory\ExtraDownloadFactoryInterface;
+
+class ExtraArchiveFactoryTest extends ExtraDownloadFactoryTest
+{
+    protected function createFactory(): ExtraDownloadFactoryInterface
+    {
+        return new ExtraArchiveFactory($this->attributeManager);
+    }
+
+    protected function getExtraDownloadClass(): string
+    {
+        return ExtraArchive::class;
+    }
+
+    protected function getAttributesMap(): array
+    {
+        return [
+            ...parent::getAttributesMap(),
+            [Attribute::IGNORE, [
+                'dir/*',
+                '!dir/file1',
+            ]],
+        ];
+    }
+}

--- a/tests/Unit/Factory/ExtraDownloadFactoryTest.php
+++ b/tests/Unit/Factory/ExtraDownloadFactoryTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Tests\Unit\Factory;
+
+use Composer\Package\Package;
+use Composer\Package\PackageInterface;
+use LastCall\DownloadsPlugin\Attribute\AttributeManagerInterface;
+use LastCall\DownloadsPlugin\Composer\Package\ExtraDownload;
+use LastCall\DownloadsPlugin\Enum\Attribute;
+use LastCall\DownloadsPlugin\Enum\Type;
+use LastCall\DownloadsPlugin\Factory\ExtraDownloadFactory;
+use LastCall\DownloadsPlugin\Factory\ExtraDownloadFactoryInterface;
+use LastCall\DownloadsPlugin\Model\Hash;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ExtraDownloadFactoryTest extends TestCase
+{
+    private PackageInterface $parent;
+    protected AttributeManagerInterface|MockObject $attributeManager;
+    private ExtraDownloadFactoryInterface $factory;
+
+    protected function setUp(): void
+    {
+        $this->parent = new Package('vendor/package-name', '1.0.0', 'v1.0.0');
+        $this->attributeManager = $this->createMock(AttributeManagerInterface::class);
+        $this->factory = $this->createFactory();
+    }
+
+    public function testCreate(): void
+    {
+        $attributesMap = $this->getAttributesMap();
+        $this->attributeManager
+            ->expects($this->exactly(\count($attributesMap)))
+            ->method('get')
+            ->willReturnMap($attributesMap);
+        $extraDownload = $this->factory->create(
+            $id = 'file-name',
+            $this->parent
+        );
+        $this->assertInstanceOf($this->getExtraDownloadClass(), $extraDownload);
+        $this->assertSame(sprintf('vendor/package-name:%s', $id), $extraDownload->getName());
+        $this->assertSame(ExtraDownload::FAKE_VERSION, $extraDownload->getVersion());
+        $this->assertSame('v1.2.3', $extraDownload->getPrettyVersion());
+        $this->assertSame('http://example.com/file.zip', $extraDownload->getDistUrl());
+        $this->assertSame('zip', $extraDownload->getDistType());
+        $this->assertSame('path/to/dir', $extraDownload->getTargetDir());
+        $this->assertSame('dist', $extraDownload->getInstallationSource());
+        $this->assertSame('extra-download:archive', $extraDownload->getType());
+    }
+
+    protected function createFactory(): ExtraDownloadFactoryInterface
+    {
+        return new ExtraDownloadFactory($this->attributeManager);
+    }
+
+    protected function getExtraDownloadClass(): string
+    {
+        return ExtraDownload::class;
+    }
+
+    protected function getAttributesMap(): array
+    {
+        return [
+            [Attribute::VERSION, 'v1.2.3'],
+            [Attribute::HASH, new Hash('md5', 'text')],
+            [Attribute::TYPE, Type::ZIP],
+            [Attribute::EXECUTABLE, [
+                'file1',
+                'path/to/file2',
+            ]],
+            [Attribute::URL, 'http://example.com/file.zip'],
+            [Attribute::PATH, 'path/to/dir'],
+        ];
+    }
+}


### PR DESCRIPTION
* `ExtraArchive` and `ExtraDownload` are quite similar classes, with 1 extra constructor's parameter.
* That's why factories for them are quite similar: `ExtraArchiveFactory`, `ExtraDownloadFactory`