### PR TITLE
refactor(2.0): Add ArchiveInstaller

### DIFF
--- a/src/Composer/Installer/AbstractInstaller.php
+++ b/src/Composer/Installer/AbstractInstaller.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Composer\Installer;
+
+use Composer\Composer;
+use Composer\Installer\InstallerInterface;
+use Composer\IO\IOInterface;
+use Composer\Package\PackageInterface;
+use Composer\Repository\InstalledRepositoryInterface;
+use LastCall\DownloadsPlugin\Composer\Package\ExtraDownloadInterface;
+use LastCall\DownloadsPlugin\Exception\ExtraDownloadHashMismatchException;
+use LastCall\DownloadsPlugin\Installer\ExecutableInstaller;
+use LastCall\DownloadsPlugin\Installer\ExecutableInstallerInterface;
+use React\Promise\PromiseInterface;
+
+abstract class AbstractInstaller implements InstallerInterface
+{
+    private ExecutableInstallerInterface $executableInstaller;
+
+    public function __construct(
+        private IOInterface $io,
+        protected Composer $composer,
+        ?ExecutableInstallerInterface $executableInstaller = null,
+    ) {
+        $this->executableInstaller = $executableInstaller ?? new ExecutableInstaller($this->io);
+    }
+
+    public function isInstalled(InstalledRepositoryInterface $repo, PackageInterface $package): bool
+    {
+        if (!$package instanceof ExtraDownloadInterface) {
+            return false;
+        }
+
+        $hasPackage = $repo->hasPackage($package);
+        $fileExists = file_exists($package->getInstallPath());
+
+        if (!$hasPackage && $fileExists) {
+            $this->io->write(
+                sprintf(
+                    '<info>Extra file <comment>%s</comment> has been locally overriden in <comment>%s</comment>. To reset it, delete and reinstall.</info>',
+                    $package->getName(),
+                    $package->getTargetDir()
+                ),
+                true
+            );
+
+            return true;
+        }
+
+        if ($hasPackage && $fileExists) {
+            $this->io->write(
+                sprintf('<info>Skip extra file <comment>%s</comment></info>', $package->getName()),
+                true,
+                IOInterface::VERY_VERBOSE
+            );
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public function download(PackageInterface $package, ?PackageInterface $prevPackage = null): PromiseInterface
+    {
+        if (!$package instanceof ExtraDownloadInterface) {
+            return \React\Promise\resolve(null);
+        }
+
+        $targetDir = \dirname($package->getInstallPath());
+        $promise = $this->composer->getDownloadManager()->download($package, $targetDir);
+
+        return $promise->then(function (string $result) use ($package, $targetDir) {
+            if ($package->verifyFile($result)) {
+                return \React\Promise\resolve($result);
+            }
+            $this->io->error(sprintf('    Extra file "%s" does not match hash value defined in "%s".', $package->getDistUrl(), $package->getName()));
+            $this->composer->getDownloadManager()->cleanup('install', $package, $targetDir);
+
+            return \React\Promise\reject(new ExtraDownloadHashMismatchException());
+        });
+    }
+
+    public function prepare(string $type, PackageInterface $package, ?PackageInterface $prevPackage = null): PromiseInterface
+    {
+        return \React\Promise\resolve(null);
+    }
+
+    public function cleanup(string $type, PackageInterface $package, ?PackageInterface $prevPackage = null): PromiseInterface
+    {
+        return \React\Promise\resolve(null);
+    }
+
+    public function install(InstalledRepositoryInterface $repo, PackageInterface $package): PromiseInterface
+    {
+        if ($package instanceof ExtraDownloadInterface) {
+            $this->executableInstaller->install($package);
+        }
+
+        if (!$repo->hasPackage($package)) {
+            $repo->addPackage($package);
+        }
+
+        return \React\Promise\resolve(null);
+    }
+
+    public function update(InstalledRepositoryInterface $repo, PackageInterface $initial, PackageInterface $target): PromiseInterface
+    {
+        return \React\Promise\resolve(null);
+    }
+
+    public function uninstall(InstalledRepositoryInterface $repo, PackageInterface $package): PromiseInterface
+    {
+        return \React\Promise\resolve(null);
+    }
+
+    public function getInstallPath(PackageInterface $package): ?string
+    {
+        if ($package instanceof ExtraDownloadInterface) {
+            return $package->getInstallPath();
+        }
+
+        return null;
+    }
+}

--- a/src/Composer/Installer/ArchiveInstaller.php
+++ b/src/Composer/Installer/ArchiveInstaller.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Composer\Installer;
+
+use Composer\Package\PackageInterface;
+use Composer\Repository\InstalledRepositoryInterface;
+use LastCall\DownloadsPlugin\Composer\Package\ExtraArchiveInterface;
+use LastCall\DownloadsPlugin\Enum\PackageType;
+use React\Promise\PromiseInterface;
+
+class ArchiveInstaller extends AbstractInstaller
+{
+    public function supports(string $packageType): bool
+    {
+        return $packageType === PackageType::ARCHIVE->value;
+    }
+
+    public function install(InstalledRepositoryInterface $repo, PackageInterface $package): PromiseInterface
+    {
+        if (!$package instanceof ExtraArchiveInterface) {
+            return \React\Promise\resolve(null);
+        }
+
+        $promise = $this->composer->getDownloadManager()->install($package, $package->getInstallPath());
+
+        return $promise->then(function () use ($repo, $package) {
+            $package->clean();
+
+            return parent::install($repo, $package);
+        });
+    }
+}

--- a/src/Exception/ExtraDownloadHashMismatchException.php
+++ b/src/Exception/ExtraDownloadHashMismatchException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Exception;
+
+class ExtraDownloadHashMismatchException extends BaseException
+{
+}

--- a/tests/Unit/Composer/Installer/AbstractInstallerTestCase.php
+++ b/tests/Unit/Composer/Installer/AbstractInstallerTestCase.php
@@ -1,0 +1,263 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Tests\Unit\Composer\Installer;
+
+use Composer\Composer;
+use Composer\Downloader\DownloadManager;
+use Composer\Installer\InstallerInterface;
+use Composer\IO\IOInterface;
+use Composer\Package\PackageInterface;
+use Composer\Repository\InstalledRepositoryInterface;
+use LastCall\DownloadsPlugin\Composer\Package\ExtraDownloadInterface;
+use LastCall\DownloadsPlugin\Exception\ExtraDownloadHashMismatchException;
+use LastCall\DownloadsPlugin\Installer\ExecutableInstallerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use React\Promise\Promise;
+use VirtualFileSystem\FileSystem as VirtualFileSystem;
+
+abstract class AbstractInstallerTestCase extends TestCase
+{
+    private ?VirtualFileSystem $fs = null;
+    protected Composer|MockObject $composer;
+    protected IOInterface|MockObject $io;
+    protected DownloadManager|MockObject $downloadManager;
+    protected ExecutableInstallerInterface|MockObject $executableInstaller;
+    protected InstalledRepositoryInterface|MockObject $repository;
+    protected ExtraDownloadInterface|MockObject $extraDownload;
+    protected PackageInterface|MockObject $package;
+    protected InstallerInterface $installer;
+    protected string $installPath = '/path/to/package/files/new-file';
+    private string $url = 'http://example.com/file.ext';
+    private string $name = 'vendor/parent-package:extra-download-name';
+    private string $targetDir = 'files/new-file';
+
+    protected function setUp(): void
+    {
+        $this->fs = new VirtualFileSystem();
+        $this->composer = $this->createMock(Composer::class);
+        $this->io = $this->createMock(IOInterface::class);
+        $this->downloadManager = $this->createMock(DownloadManager::class);
+        $this->executableInstaller = $this->createMock(ExecutableInstallerInterface::class);
+        $this->repository = $this->createMock(InstalledRepositoryInterface::class);
+        $this->extraDownload = $this->createMock(ExtraDownloadInterface::class);
+        $this->package = $this->createMock(PackageInterface::class);
+        $this->installer = $this->createInstaller();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->fs = null;
+    }
+
+    public function testIsInstalledPackage(): void
+    {
+        $this->assertFalse($this->installer->isInstalled($this->repository, $this->package));
+    }
+
+    public function getIsInstalledExtraDownloadTests(): array
+    {
+        return [
+            [true, true, true],
+            [false, true, true],
+            [true, false, false],
+            [false, false, false],
+        ];
+    }
+
+    /**
+     * @dataProvider getIsInstalledExtraDownloadTests
+     */
+    public function testIsInstalledExtraDownload(bool $hasPackage, bool $fileExists, bool $isInstalled): void
+    {
+        $this->repository
+            ->expects($this->once())
+            ->method('hasPackage')
+            ->with($this->extraDownload)
+            ->willReturn($hasPackage);
+        $this->extraDownload
+            ->expects($this->once())
+            ->method('getInstallPath')
+            ->willReturn($this->fs->path($this->installPath));
+        if ($fileExists) {
+            $this->fs->createDirectory(\dirname($this->installPath), true);
+            $this->fs->createFile($this->installPath, 'downloaded file');
+        }
+        if ($fileExists) {
+            $this->extraDownload
+                ->expects($this->once())
+                ->method('getName')
+                ->willReturn($this->name);
+        }
+        if (!$hasPackage && $fileExists) {
+            $this->extraDownload
+                ->expects($this->once())
+                ->method('getTargetDir')
+                ->willReturn($this->targetDir);
+            $this->io
+                ->expects($this->once())
+                ->method('write')
+                ->with(
+                    sprintf(
+                        '<info>Extra file <comment>%s</comment> has been locally overriden in <comment>%s</comment>. To reset it, delete and reinstall.</info>',
+                        $this->name,
+                        $this->targetDir,
+                    ),
+                    true
+                );
+        }
+        if ($hasPackage && $fileExists) {
+            $this->io
+                ->expects($this->once())
+                ->method('write')
+                ->with(
+                    sprintf('<info>Skip extra file <comment>%s</comment></info>', $this->name),
+                    true,
+                    IOInterface::VERY_VERBOSE
+                );
+        }
+        $this->assertSame($isInstalled, $this->installer->isInstalled($this->repository, $this->extraDownload));
+    }
+
+    public function testDownloadPackage(): void
+    {
+        $promise = $this->installer->download($this->package);
+        $promise->then(function ($result) {
+            $this->assertNull($result);
+        });
+    }
+
+    public function testDownloadValidExtraFile(): void
+    {
+        $this->composer
+            ->expects($this->once())
+            ->method('getDownloadManager')
+            ->willReturn($this->downloadManager);
+        $targetDir = \dirname($this->installPath);
+        $downloadedPath = '/path/to/vendor/composer/tmp-abc123.ext';
+        $downloaderPromise = new Promise(fn (callable $resolve) => $resolve($downloadedPath));
+        $this->downloadManager
+            ->expects($this->once())
+            ->method('download')
+            ->with($this->extraDownload, $targetDir)
+            ->willReturn($downloaderPromise);
+        $this->extraDownload
+            ->expects($this->once())
+            ->method('getInstallPath')
+            ->willReturn($this->installPath);
+        $this->extraDownload
+            ->expects($this->once())
+            ->method('verifyFile')
+            ->with($downloadedPath)
+            ->willReturn(true);
+        $installerPromise = $this->installer->download($this->extraDownload);
+        $installerPromise->then(function ($result) use ($downloadedPath) {
+            $this->assertSame($downloadedPath, $result);
+        });
+    }
+
+    public function testDownloadInvalidExtraFile(): void
+    {
+        $this->composer
+            ->expects($this->exactly(2))
+            ->method('getDownloadManager')
+            ->willReturn($this->downloadManager);
+        $targetDir = \dirname($this->installPath);
+        $downloadedPath = '/path/to/vendor/composer/tmp-abc123.ext';
+        $downloaderPromise = new Promise(fn (callable $resolve) => $resolve($downloadedPath));
+        $this->downloadManager
+            ->expects($this->once())
+            ->method('download')
+            ->with($this->extraDownload, $targetDir)
+            ->willReturn($downloaderPromise);
+        $this->extraDownload
+            ->expects($this->once())
+            ->method('getInstallPath')
+            ->willReturn($this->installPath);
+        $this->extraDownload
+            ->expects($this->once())
+            ->method('getInstallPath')
+            ->willReturn($this->installPath);
+        $this->extraDownload
+            ->expects($this->once())
+            ->method('getDistUrl')
+            ->willReturn($this->url);
+        $this->extraDownload
+            ->expects($this->once())
+            ->method('getName')
+            ->willReturn($this->name);
+        $this->extraDownload
+            ->expects($this->once())
+            ->method('verifyFile')
+            ->with($downloadedPath)
+            ->willReturn(false);
+        $this->io
+            ->expects($this->once())
+            ->method('error')
+            ->with(sprintf('    Extra file "%s" does not match hash value defined in "%s".', $this->url, $this->name));
+        $this->downloadManager
+            ->expects($this->once())
+            ->method('cleanup')
+            ->with('install', $this->extraDownload, $targetDir);
+        $installerPromise = $this->installer->download($this->extraDownload);
+        $installerPromise->then(null, function ($result) {
+            $this->assertInstanceOf(ExtraDownloadHashMismatchException::class, $result);
+        });
+    }
+
+    public function testPrepare(): void
+    {
+        $promise = $this->installer->prepare('install', $this->extraDownload);
+        $promise->then(function ($result) {
+            $this->assertNull($result);
+        });
+    }
+
+    public function testCleanup(): void
+    {
+        $promise = $this->installer->cleanup('install', $this->extraDownload);
+        $promise->then(function ($result) {
+            $this->assertNull($result);
+        });
+    }
+
+    public function testUpdate(): void
+    {
+        $promise = $this->installer->update($this->repository, $this->extraDownload, $this->extraDownload);
+        $promise->then(function ($result) {
+            $this->assertNull($result);
+        });
+    }
+
+    public function testUninstall(): void
+    {
+        $promise = $this->installer->uninstall($this->repository, $this->extraDownload);
+        $promise->then(function ($result) {
+            $this->assertNull($result);
+        });
+    }
+
+    public function testPackageInstallPath(): void
+    {
+        $this->assertNull($this->installer->getInstallPath($this->package));
+    }
+
+    public function testExtraDownloadInstallPath(): void
+    {
+        $this->extraDownload
+            ->expects($this->once())
+            ->method('getInstallPath')
+            ->willReturn($this->installPath);
+        $this->assertSame($this->installPath, $this->installer->getInstallPath($this->extraDownload));
+    }
+
+    public function testInstallPackage(): void
+    {
+        $promise = $this->installer->install($this->repository, $this->package);
+        $promise->then(function ($result) {
+            $this->assertNull($result);
+        });
+    }
+
+    abstract protected function createInstaller(): InstallerInterface;
+}

--- a/tests/Unit/Composer/Installer/ArchiveInstallerTest.php
+++ b/tests/Unit/Composer/Installer/ArchiveInstallerTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Tests\Unit\Composer\Installer;
+
+use Composer\Installer\InstallerInterface;
+use LastCall\DownloadsPlugin\Composer\Installer\ArchiveInstaller;
+use LastCall\DownloadsPlugin\Composer\Package\ExtraArchiveInterface;
+use LastCall\DownloadsPlugin\Composer\Package\ExtraDownloadInterface;
+use React\Promise\Promise;
+
+class ArchiveInstallerTest extends AbstractInstallerTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->extraDownload = $this->createMock(ExtraArchiveInterface::class);
+    }
+
+    protected function createInstaller(): InstallerInterface
+    {
+        return new ArchiveInstaller($this->io, $this->composer, $this->executableInstaller);
+    }
+
+    public function testInstallExtraDownload(): void
+    {
+        $package = $this->createMock(ExtraDownloadInterface::class);
+        $promise = $this->installer->install($this->repository, $package);
+        $promise->then(function ($result) {
+            $this->assertNull($result);
+        });
+    }
+
+    public function getInstallExtraArchiveTests(): array
+    {
+        return [
+            [true],
+            [false],
+        ];
+    }
+
+    /**
+     * @dataProvider getInstallExtraArchiveTests
+     */
+    public function testInstallExtraArchive(bool $hasPackage): void
+    {
+        $this->composer
+            ->expects($this->once())
+            ->method('getDownloadManager')
+            ->willReturn($this->downloadManager);
+        $downloaderPromise = new Promise(fn (callable $resolve) => $resolve(null));
+        $this->downloadManager
+            ->expects($this->once())
+            ->method('install')
+            ->with($this->extraDownload, $this->installPath)
+            ->willReturn($downloaderPromise);
+        $this->extraDownload
+            ->expects($this->once())
+            ->method('getInstallPath')
+            ->willReturn($this->installPath);
+        $this->extraDownload
+            ->expects($this->once())
+            ->method('clean');
+        $this->executableInstaller
+            ->expects($this->once())
+            ->method('install')
+            ->with($this->extraDownload);
+        $this->repository
+            ->expects($this->once())
+            ->method('hasPackage')
+            ->with($this->extraDownload)
+            ->willReturn($hasPackage);
+        $this->repository
+            ->expects($this->exactly(!$hasPackage))
+            ->method('addPackage')
+            ->with($this->extraDownload);
+        $installerPromise = $this->installer->install($this->repository, $this->extraDownload);
+        $installerPromise->then(function ($result) {
+            $this->assertNull($result);
+        });
+    }
+}


### PR DESCRIPTION
This is the second PR that add code to use Composer's terms. This one use the term `Installer`.

* First, `ArchiveInstaller` download the extra archive
* If the downloaded file is not valid (hashes doesn't match), then throw an error
* If the downloaded file is valid, then it extract the file
* Then the installer will cleanup files that are ignored
* Then the installer will make files executable
* Then it mark the extra archive as installed in the repository