### PR TITLE
refactor(2.0): Add FileInstaller

### DIFF
--- a/src/Composer/Installer/FileInstaller.php
+++ b/src/Composer/Installer/FileInstaller.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Composer\Installer;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Composer\Package\PackageInterface;
+use Composer\Repository\InstalledRepositoryInterface;
+use Composer\Util\Filesystem;
+use LastCall\DownloadsPlugin\Composer\Package\ExtraDownloadInterface;
+use LastCall\DownloadsPlugin\Enum\PackageType;
+use LastCall\DownloadsPlugin\Installer\ExecutableInstallerInterface;
+use React\Promise\PromiseInterface;
+use Symfony\Component\Finder\Finder;
+
+class FileInstaller extends AbstractInstaller
+{
+    public const TMP_PREFIX = '.composer-extra-tmp-';
+
+    protected Filesystem $filesystem;
+
+    public function __construct(
+        IOInterface $io,
+        Composer $composer,
+        ?Filesystem $filesystem = null,
+        ?ExecutableInstallerInterface $executableInstaller = null,
+    ) {
+        parent::__construct($io, $composer, $executableInstaller);
+        $this->filesystem = $filesystem ?: new Filesystem();
+    }
+
+    public function supports(string $packageType): bool
+    {
+        return $packageType === PackageType::FILE->value;
+    }
+
+    public function install(InstalledRepositoryInterface $repo, PackageInterface $package): PromiseInterface
+    {
+        if (!$package instanceof ExtraDownloadInterface) {
+            return \React\Promise\resolve(null);
+        }
+
+        $expectedPath = $package->getInstallPath();
+        $tmpDir = \dirname($expectedPath).\DIRECTORY_SEPARATOR.uniqid(self::TMP_PREFIX, true);
+        $promise = $this->composer->getDownloadManager()->install($package, $tmpDir);
+
+        return $promise->then(function () use ($repo, $package, $expectedPath, $tmpDir) {
+            $finder = new Finder();
+            foreach ($finder->files()->in($tmpDir) as $file) {
+                $this->filesystem->rename($file, $expectedPath);
+                break;
+            }
+            $this->filesystem->remove($tmpDir);
+
+            return parent::install($repo, $package);
+        });
+    }
+}

--- a/tests/Unit/Composer/Installer/AbstractInstallerTestCase.php
+++ b/tests/Unit/Composer/Installer/AbstractInstallerTestCase.php
@@ -18,7 +18,7 @@ use VirtualFileSystem\FileSystem as VirtualFileSystem;
 
 abstract class AbstractInstallerTestCase extends TestCase
 {
-    private ?VirtualFileSystem $fs = null;
+    protected ?VirtualFileSystem $fs = null;
     protected Composer|MockObject $composer;
     protected IOInterface|MockObject $io;
     protected DownloadManager|MockObject $downloadManager;

--- a/tests/Unit/Composer/Installer/ArchiveInstallerTest.php
+++ b/tests/Unit/Composer/Installer/ArchiveInstallerTest.php
@@ -21,6 +21,15 @@ class ArchiveInstallerTest extends AbstractInstallerTestCase
         return new ArchiveInstaller($this->io, $this->composer, $this->executableInstaller);
     }
 
+    /**
+     * @testWith ["extra-download:file", false]
+     *           ["extra-download:archive", true]
+     */
+    public function testSupports(string $type, bool $supports): void
+    {
+        $this->assertSame($supports, $this->installer->supports($type));
+    }
+
     public function testInstallExtraDownload(): void
     {
         $package = $this->createMock(ExtraDownloadInterface::class);
@@ -30,16 +39,9 @@ class ArchiveInstallerTest extends AbstractInstallerTestCase
         });
     }
 
-    public function getInstallExtraArchiveTests(): array
-    {
-        return [
-            [true],
-            [false],
-        ];
-    }
-
     /**
-     * @dataProvider getInstallExtraArchiveTests
+     * @testWith [true]
+     *           [false]
      */
     public function testInstallExtraArchive(bool $hasPackage): void
     {
@@ -47,7 +49,7 @@ class ArchiveInstallerTest extends AbstractInstallerTestCase
             ->expects($this->once())
             ->method('getDownloadManager')
             ->willReturn($this->downloadManager);
-        $downloaderPromise = new Promise(fn (callable $resolve) => $resolve(null));
+        $downloaderPromise = new Promise(fn (callable $resolver) => $resolver(null));
         $this->downloadManager
             ->expects($this->once())
             ->method('install')

--- a/tests/Unit/Composer/Installer/FileInstallerTest.php
+++ b/tests/Unit/Composer/Installer/FileInstallerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Tests\Unit\Composer\Installer;
+
+use Composer\Installer\InstallerInterface;
+use Composer\Util\Filesystem;
+use LastCall\DownloadsPlugin\Composer\Installer\FileInstaller;
+use LastCall\DownloadsPlugin\Composer\Package\ExtraDownloadInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use React\Promise\Promise;
+
+class FileInstallerTest extends AbstractInstallerTestCase
+{
+    private Filesystem|MockObject $filesystem;
+    private string $tmpDir;
+    private string $fileName = 'file.ext';
+    private string $fileContents = 'file contents';
+
+    protected function setUp(): void
+    {
+        $this->filesystem = $this->createMock(Filesystem::class);
+        parent::setUp();
+    }
+
+    protected function createInstaller(): InstallerInterface
+    {
+        return new FileInstaller($this->io, $this->composer, $this->filesystem, $this->executableInstaller);
+    }
+
+    /**
+     * @testWith ["extra-download:file", true]
+     *           ["extra-download:archive", false]
+     */
+    public function testSupports(string $type, bool $supports): void
+    {
+        $this->assertSame($supports, $this->installer->supports($type));
+    }
+
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testInstallExtraDownload(bool $hasPackage): void
+    {
+        $this->composer
+            ->expects($this->once())
+            ->method('getDownloadManager')
+            ->willReturn($this->downloadManager);
+        $this->downloadManager
+            ->expects($this->once())
+            ->method('install')
+            ->with($this->extraDownload, $this->callback(function (string $targetDir): bool {
+                $this->assertTrue(str_contains($targetDir, FileInstaller::TMP_PREFIX));
+
+                return true;
+            }))
+            ->willReturnCallback(function (ExtraDownloadInterface $extraDownload, string $tmpDir) {
+                $this->tmpDir = $tmpDir;
+                mkdir($this->tmpDir, 0777, true);
+                file_put_contents($this->tmpDir.\DIRECTORY_SEPARATOR.$this->fileName, $this->fileContents);
+
+                $this->filesystem
+                    ->expects($this->once())
+                    ->method('rename')
+                    ->with($this->tmpDir.\DIRECTORY_SEPARATOR.$this->fileName, $this->fs->path($this->installPath));
+                $this->filesystem
+                    ->expects($this->once())
+                    ->method('remove')
+                    ->with($this->tmpDir);
+
+                $downloaderPromise = new Promise(fn (callable $resolve) => $resolve(null));
+
+                return $downloaderPromise;
+            });
+        $this->extraDownload
+            ->expects($this->once())
+            ->method('getInstallPath')
+            ->willReturn($this->fs->path($this->installPath));
+        $this->executableInstaller
+            ->expects($this->once())
+            ->method('install')
+            ->with($this->extraDownload);
+        $this->repository
+            ->expects($this->once())
+            ->method('hasPackage')
+            ->with($this->extraDownload)
+            ->willReturn($hasPackage);
+        $this->repository
+            ->expects($this->exactly(!$hasPackage))
+            ->method('addPackage')
+            ->with($this->extraDownload);
+        $installerPromise = $this->installer->install($this->repository, $this->extraDownload);
+        $installerPromise->then(function ($result) {
+            $this->assertNull($result);
+        });
+    }
+}


### PR DESCRIPTION
* First, `FileInstaller` download the extra file
* If the downloaded file is not valid (hashes doesn't match), then throw an error
* If the downloaded file is valid, then it move (normal file)/extract (gzip file) into a temporary directory
* Then the installer will move the only file inside temporary directory into expected path
* Then the installer will remove temporary directory
* Then the installer will make file executable (if needed)
* Then it mark the extra file as installed in the repository