### PR TITLE
ci: Run integration tests with lowest composer version (2.3)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.1, 8.2, 8.3]
+        dependencies: [ 'lowest', 'highest' ]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
@@ -47,7 +48,7 @@ jobs:
         if: ${{ matrix.os == 'macos-latest' }}
       - uses: ramsey/composer-install@v3
         with:
-          dependency-versions: 'highest'
+          dependency-versions: ${{ matrix.dependencies }}
       - name: Run integration tests
         run: ./vendor/bin/phpunit --testsuite=Integration
 


### PR DESCRIPTION
Lowest supported composer version is `2.3`

Currently it does not match the version of `composer-plugin-api` (`^2.1`). I'm not sure if it's okay or not. There are no information about it in https://getcomposer.org/doc/articles/plugins.md#plugin-package
