### PR TITLE
test: Replace system paths by made-up paths

### DIFF
--- a/tests/Integration/Invalid/InvalidUrlTest.php
+++ b/tests/Integration/Invalid/InvalidUrlTest.php
@@ -12,7 +12,7 @@ class InvalidUrlTest extends InstallInvalidExtraDownloadsTest
     protected static function getExtraFile(): array
     {
         return [
-            'url' => '/etc/passwd',
+            'url' => '/path/to/system/file',
         ];
     }
 

--- a/tests/Unit/Attribute/Validator/UrlValidatorTest.php
+++ b/tests/Unit/Attribute/Validator/UrlValidatorTest.php
@@ -43,8 +43,8 @@ class UrlValidatorTest extends AbstractValidatorTestCase
     {
         return [
             [''],
-            ['C:\Programs\PHP\php.ini'],
-            ['/var/www/project/uploads'],
+            ['Z:\path\to\file.txt'],
+            ['/path/to/any/directory'],
         ];
     }
 


### PR DESCRIPTION
This is suggestion from Lewis. I think it's to prevent something bad happen when the tests is not running correctly.