### PR TITLE
fix: Allow update extra file without manually deletion

### DIFF
--- a/src/Composer/Repository/ExtraDownloadsRepository.php
+++ b/src/Composer/Repository/ExtraDownloadsRepository.php
@@ -5,11 +5,10 @@ namespace LastCall\DownloadsPlugin\Composer\Repository;
 use Composer\Installer\InstallationManager;
 use Composer\Json\JsonFile;
 use Composer\Package\PackageInterface;
-use Composer\Repository\InstalledRepositoryInterface;
 use Composer\Repository\InvalidRepositoryException;
 use LastCall\DownloadsPlugin\Composer\Package\ExtraDownloadInterface;
 
-class ExtraDownloadsRepository implements InstalledRepositoryInterface
+class ExtraDownloadsRepository implements ExtraDownloadsRepositoryInterface
 {
     private array $extraDownloads;
 
@@ -43,6 +42,11 @@ class ExtraDownloadsRepository implements InstalledRepositoryInterface
         }
 
         return $this->extraDownloads[$name] === $package->getTrackingChecksum();
+    }
+
+    public function isTracked(ExtraDownloadInterface $package): bool
+    {
+        return isset($this->extraDownloads[$package->getName()]);
     }
 
     protected function initialize(): void

--- a/src/Composer/Repository/ExtraDownloadsRepositoryInterface.php
+++ b/src/Composer/Repository/ExtraDownloadsRepositoryInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace LastCall\DownloadsPlugin\Composer\Repository;
+
+use Composer\Repository\InstalledRepositoryInterface;
+use LastCall\DownloadsPlugin\Composer\Package\ExtraDownloadInterface;
+
+interface ExtraDownloadsRepositoryInterface extends InstalledRepositoryInterface
+{
+    public function isTracked(ExtraDownloadInterface $extraDownload): bool;
+}

--- a/tests/Unit/Composer/Repository/ExtraDownloadsRepositoryTest.php
+++ b/tests/Unit/Composer/Repository/ExtraDownloadsRepositoryTest.php
@@ -87,16 +87,9 @@ class ExtraDownloadsRepositoryTest extends TestCase
         $this->assertFalse($this->repository->hasPackage($this->package));
     }
 
-    public function getHasExtraDownloadTests(): array
-    {
-        return [
-            [false],
-            [true],
-        ];
-    }
-
     /**
-     * @dataProvider getHasExtraDownloadTests
+     * @testWith [true]
+     *           [false]
      */
     public function testHasExtraDownload(bool $sameTrackingChecksum): void
     {
@@ -112,6 +105,21 @@ class ExtraDownloadsRepositoryTest extends TestCase
         $this->assertFalse($this->repository->hasPackage($this->extraDownload));
         $this->repository->addPackage($this->extraDownload);
         $this->assertSame($sameTrackingChecksum, $this->repository->hasPackage($this->extraDownload));
+    }
+
+    public function testIsTracked(): void
+    {
+        $this->extraDownload
+            ->expects($this->exactly(3))
+            ->method('getName')
+            ->willReturn($this->name);
+        $this->extraDownload
+            ->expects($this->once())
+            ->method('getTrackingChecksum')
+            ->willReturn($this->trackingChecksum);
+        $this->assertFalse($this->repository->isTracked($this->extraDownload));
+        $this->repository->addPackage($this->extraDownload);
+        $this->assertTrue($this->repository->isTracked($this->extraDownload));
     }
 
     public function testReloadFromInvalidFile(): void


### PR DESCRIPTION
There is a regression on `2.0` compared to `1.0`, that is:

When update extra file to new version, this warning is always displayed:

```
Extra file some-name has been locally overriden in path/to/file. To reset it, delete and reinstall.
```

It's because of the wrong condition. I reverted to the old condition in https://github.com/pact-foundation/composer-downloads-plugin/blob/v1.0.0/src/SubpackageInstaller.php